### PR TITLE
[cov] Add hmac stop bug sw workaround

### DIFF
--- a/run_all_coverage.sh
+++ b/run_all_coverage.sh
@@ -347,9 +347,7 @@ CRYPTO_TESTS=(
 //sw/device/tests/crypto/cryptotest:sha512_kat_fpga_cw310_sival_rom_ext
 //sw/device/tests/crypto/cryptotest:shake128_kat_fpga_cw310_sival_rom_ext
 //sw/device/tests/crypto/cryptotest:shake256_kat_fpga_cw310_sival_rom_ext
-
-# Timeout: SPX
-# //sw/device/tests/crypto/cryptotest:sphincsplus_kat_fpga_cw310_sival_rom_ext
+//sw/device/tests/crypto/cryptotest:sphincsplus_kat_fpga_cw310_sival_rom_ext
 )
 
 CW310_SIVAL_ROMEXT_TESTS=(
@@ -538,28 +536,28 @@ CW310_SIVAL_ROMEXT_TESTS=(
 //sw/device/tests/crypto:sha512_functest_fpga_cw310_sival_rom_ext
 //sw/device/tests/crypto:symmetric_keygen_functest_fpga_cw310_sival_rom_ext
 
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:fors_test_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:mgf1_test_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:thash_test_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_hardcoded_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat0_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat1_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat2_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat3_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat4_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat5_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat6_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat7_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat8_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat9_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify/sphincsplus/test:wots_test_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/sigverify:spx_verify_functest_fpga_cw310_sival_rom_ext
+//sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310_sival_rom_ext
+
 # CE: OpenOCD
 # //sw/device/tests:crt_test_fpga_cw310_sival_rom_ext
 # //sw/device/tests:rv_core_ibex_isa_test_test_unlocked0_fpga_cw310_sival_rom_ext
 # //sw/device/tests:rv_core_ibex_mem_test_test_unlocked0_fpga_cw310_sival_rom_ext
-
-# ?: SPX
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:fors_test_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:mgf1_test_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:thash_test_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_hardcoded_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat0_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat1_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat2_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat3_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat4_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat5_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat6_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat7_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat8_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:verify_test_kat9_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify/sphincsplus/test:wots_test_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/sigverify:spx_verify_functest_fpga_cw310_sival_rom_ext
 
 # ?: USBDEV
 # //sw/device/tests:usbdev_config_host_test_fpga_cw310_sival_rom_ext
@@ -583,7 +581,6 @@ CW310_SIVAL_ROMEXT_TESTS=(
 # //sw/device/tests:uart_baud_rate_test_fpga_cw310_sival_rom_ext
 # //sw/device/tests:uart_loopback_test_fpga_cw310_sival_rom_ext
 # //sw/device/tests:uart_parity_break_test_fpga_cw310_sival_rom_ext
-# //sw/device/silicon_creator/lib/drivers:hmac_functest_fpga_cw310_sival_rom_ext
 # //sw/device/tests:sigverify_parallel_test_fpga_cw310_sival_rom_ext
 # //sw/device/tests:csrng_edn_concurrency_test_fpga_cw310_sival_rom_ext
 # //sw/device/tests:example_concurrency_test_fpga_cw310_sival_rom_ext
@@ -797,9 +794,8 @@ HYPER310_ROMEXT_TESTS=(
 //sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_a_update_slot_a_fpga_hyper310_rom_ext
 //sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_b_update_slot_b_fpga_hyper310_rom_ext
 
-# SPX freeze
-# //sw/device/silicon_creator/rom_ext/e2e/verified_boot:key_dev_hybrid_spx_prehashed_fpga_hyper310_rom_ext
-# //sw/device/silicon_creator/rom_ext/e2e/verified_boot:key_prod_hybrid_spx_pure_fpga_hyper310_rom_ext
+//sw/device/silicon_creator/rom_ext/e2e/verified_boot:key_dev_hybrid_spx_prehashed_fpga_hyper310_rom_ext
+//sw/device/silicon_creator/rom_ext/e2e/verified_boot:key_prod_hybrid_spx_pure_fpga_hyper310_rom_ext
 
 # Report regex
 # //sw/device/silicon_creator/rom_ext/e2e/handoff:epmp_test_fpga_hyper310_rom_ext

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -204,6 +204,7 @@ dual_cc_library(
             "@googletest//:gtest",
         ],
         shared = [
+            ":ibex",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:bitfield",
             "//sw/device/lib/base:hardened",

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -9,9 +9,17 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+enum {
+  /* Temporary delay linked to issue #24767, which should be equivalent to at
+   * least 80 clock cycles of the HMAC clock plus a margin.
+   */
+  kHmacTmpDelay = 200,
+};
 
 static void hmac_configure(bool big_endian_digest, bool hmac_mode) {
   // Clear the config, stopping the SHA engine.
@@ -147,11 +155,20 @@ void hmac_hmac_sha256(const void *data, size_t len, hmac_key_t key,
 }
 
 void hmac_sha256_save(hmac_context_t *ctx) {
-  // Issue the STOP command to halt the operation and compute the intermediate
-  // digest.
-  uint32_t cmd = bitfield_bit32_write(0, HMAC_CMD_HASH_STOP_BIT, true);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd);
-  wait_for_done();
+
+  /**
+   * Temporary workaround linked to issue #24767
+   *
+   * The HMAC HWIP is not told to stop. This will cause the HW to be in an
+   * unexpected state, which could be exited by trigerring a simple HASH process
+   * operation. Before doing that, the context should be saved (message length
+   * and digest). This context is only available after a duration equivalent to
+   * 64 clock cycles in SHA2-256 and 80 clock cycles in SHA2-384/512, after the
+   * message length is on a block boundary (512 for SHA2-256 or 1024 bits for
+   * SHA2-384/512).
+   */
+  uint32_t start = ibex_mcycle32();
+  while(ibex_mcycle32() - start < kHmacTmpDelay);
 
   // Read the digest registers. Note that endianness does not matter here,
   // because we will simply restore the registers in the same order as we saved
@@ -167,6 +184,17 @@ void hmac_sha256_save(hmac_context_t *ctx) {
                                        HMAC_MSG_LENGTH_LOWER_REG_OFFSET);
   ctx->msg_len_upper = abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR +
                                        HMAC_MSG_LENGTH_UPPER_REG_OFFSET);
+
+
+  // Temporary workaround linked to issue #24767
+  // Trigger hash_process
+  uint32_t cmd_reg = abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET);
+  cmd_reg = bitfield_bit32_write(cmd_reg, HMAC_CMD_HASH_PROCESS_BIT, true);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd_reg);
+
+  // Wait for HMAC HWIP operation to be completed.
+  wait_for_done();
+
 
   // Momentarily clear the `sha_en` bit, which clears the digest.
   uint32_t cfg =


### PR DESCRIPTION
The overhead of coverage profiling adds too much latency before issuing the
STOP command, which triggers the HMAC hardware issue.

This commit ports the software workaround from cryptolib to the ROM/ROM_EXT
driver.