### PR TITLE
[cov] clear inline for non-static func definition

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -57,7 +57,7 @@ void hmac_sha256_configure(bool big_endian_digest) {
   hmac_configure(big_endian_digest, /*hmac_mode=*/false);
 }
 
-static inline void hmac_sha256_start(void) {
+void hmac_sha256_start(void) {
   uint32_t cmd = bitfield_bit32_write(0, HMAC_CMD_HASH_START_BIT, true);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd);
 }
@@ -92,7 +92,7 @@ void hmac_sha256_update_words(const uint32_t *data, size_t len) {
   }
 }
 
-static inline void hmac_sha256_process(void) {
+void hmac_sha256_process(void) {
   uint32_t cmd = bitfield_bit32_write(0, HMAC_CMD_HASH_PROCESS_BIT, true);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, cmd);
 }

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/hash_sha2.c
@@ -49,7 +49,7 @@ static_assert(
     kSpxLeafBits <= 32,
     "For the given height, 32 bits is not large enough for a leaf index.");
 
-static inline rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
+rom_error_t spx_hash_initialize(spx_ctx_t *ctx) {
   hmac_sha256_configure(/*big_endian_digest=*/true);
 
   // Save state for the first part of `thash`: public key seed + padding.

--- a/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.c
+++ b/sw/device/silicon_creator/lib/sigverify/sphincsplus/verify.c
@@ -95,6 +95,6 @@ rom_error_t spx_verify(const uint32_t *sig, const uint8_t *msg_prefix_1,
   return kErrorOk;
 }
 
-static inline void spx_public_key_root(const uint32_t *pk, uint32_t *root) {
+void spx_public_key_root(const uint32_t *pk, uint32_t *root) {
   memcpy(root, pk + kSpxNWords, kSpxN);
 }


### PR DESCRIPTION
Fix compilation errors in:
* #29