### PR TITLE
[cov] Add invalid dfu command test

### DIFF
--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -764,3 +764,25 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:rescue_test",
     ),
 )
+
+opentitan_test(
+    name = "spidfu_invalid_cmd",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_rescue_owner_block_invalid_state": "romext",
+            "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
+        },
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=spi-dfu-invalid-cmd
+        """,
+        test_harness = "//sw/host/tests/rescue:rescue_test",
+    ),
+)

--- a/sw/host/opentitanlib/src/rescue/dfu.rs
+++ b/sw/host/opentitanlib/src/rescue/dfu.rs
@@ -64,6 +64,7 @@ pub enum DfuRequestType {
     Out = 0x21,    // direction=out, type=class, recipient=interface.
     In = 0xA1,     // direction=in, type=class, recipient=interface.
     Vendor = 0x40, // direction=out, type=vendor, recipient=device.
+    Interface = 0x01, // Fake.
 }
 
 impl From<DfuRequestType> for u8 {

--- a/targets_min_set.sh
+++ b/targets_min_set.sh
@@ -71,6 +71,7 @@ HYPER310_ROM_EXT_TESTS=(
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_a_update_slot_a_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_too_big_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_user_error_fpga_hyper310_rom_ext'
+  '//sw/device/silicon_creator/rom_ext/e2e/rescue:spidfu_invalid_cmd_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:spidfu_rescue_boot_svc_req_disability_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:xmodem_restricted_commands_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/secver:secver_write_test_fpga_hyper310_rom_ext'


### PR DESCRIPTION
This modifies the spidfu driver on the host side to trigger a series of invalid dfu commands when setting EraseOwner mode.

- dfu invalid rescue mode
- dfu vendor request invalid mode
- dfu kUsbSetupReqSetInterface invalid mode
- dfu interface request invalid mode
- dfu control invalid request
- dfu kUsbSetupReqGetInterface