### PR TITLE
[cov] Add dfu control tests

### DIFF
--- a/sw/device/silicon_creator/rom_ext/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/defs.bzl
@@ -248,6 +248,27 @@ TEST_OWNER_CONFIGS = {
         ],
         "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
     },
+    "spidfu_flash_limit_zero": {
+        "owner_defines": [
+            # 0x53 is 'S'pi.
+            "WITH_RESCUE_PROTOCOL=0x53",
+            # Trigger 3 is GPIO pin.
+            "WITH_RESCUE_TRIGGER=3",
+            # When the trigger is GPIO, the index is the MuxedPad to us as the sense
+            # input. Index 2 is kTopEarlgreyMuxedPadsIoa2.
+            "WITH_RESCUE_INDEX=2",
+            # GPIO param 3 means enable the internal pull resistor and trigger
+            # rescue when the GPIO is high.
+            "WITH_RESCUE_GPIO_PARAM=3",
+            # Timeout: 0x80=enter_on_fail, 0x05 = 5 seconds.
+            "WITH_RESCUE_TIMEOUT=0x85",
+            "WITH_RESCUE_START=0",
+            "WITH_RESCUE_SIZE=0",
+            # Disable the owner block check in test_owner.c so that the rescue start addr can be 0.
+            "TEST_OWNER_DISABLE_OWNER_BLOCK_CHECK=1"
+        ],
+        "rescue_module": ["//sw/device/silicon_creator/lib/rescue:rescue_spidfu"],
+    },
     "isfb": {
         "owner_defines": [
             "WITH_ISFB=1",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -786,3 +786,25 @@ opentitan_test(
         test_harness = "//sw/host/tests/rescue:rescue_test",
     ),
 )
+
+opentitan_test(
+    name = "spidfu_dfu_control",
+    exec_env = {
+        "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
+        "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+    },
+    fpga = fpga_params(
+        assemble = "{romext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
+        binaries = {
+            "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_flash_limit_zero": "romext",
+            "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
+        },
+        params = "-p spi-dfu -t gpio -v +Ioa2",
+        test_cmd = """
+        --clear-bitstream
+        --bootstrap={firmware}
+        rescue {params} --action=spi-dfu-control
+        """,
+        test_harness = "//sw/host/tests/rescue:rescue_test",
+    ),
+)

--- a/targets_min_set.sh
+++ b/targets_min_set.sh
@@ -79,6 +79,7 @@ HYPER310_ROM_EXT_TESTS=(
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_rom_ext_slot_a_update_slot_a_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_too_big_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:rescue_user_error_fpga_hyper310_rom_ext'
+  '//sw/device/silicon_creator/rom_ext/e2e/rescue:spidfu_dfu_control_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:spidfu_invalid_cmd_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:spidfu_rescue_boot_svc_req_disability_fpga_hyper310_rom_ext'
   '//sw/device/silicon_creator/rom_ext/e2e/rescue:xmodem_restricted_commands_fpga_hyper310_rom_ext'


### PR DESCRIPTION
This modifies the spidfu module on the host side to allow sending invalid spi flash commands to iterate through FSM uncover by the existing tests. Also modifies the test_owner.c to allow setting the invalid rescue config to trigger the corner cases.

- dfu control - kDfuActionNone
- dfu control - kDfuActionStateResponse
- dfu control - kDfuActionClearError
- dfu control - kDfuActionDataXfer bad length
- dfu control - kDfuActionDataXfer invalid download