### PR TITLE
[cov] Fix rom_ext_boot_services_unittest

### DIFF
--- a/run_all_coverage.sh
+++ b/run_all_coverage.sh
@@ -142,13 +142,11 @@ UNIT_TESTS=(
 //sw/device/silicon_creator/rom:boot_policy_unittest
 //sw/device/silicon_creator/rom:bootstrap_unittest
 //sw/device/silicon_creator/rom_ext:rom_ext_boot_policy_unittest
+//sw/device/silicon_creator/rom_ext:rom_ext_boot_services_unittest
 //sw/device/silicon_creator/lib/ownership:owner_block_unittest
 //sw/device/lib/ujson/rust:roundtrip_test
 //sw/device/silicon_creator/manuf/base:perso_tlv_data_unittest
 //sw/device/silicon_creator/lib/ownership:ownership_unittest
-
-# ???
-# //sw/device/silicon_creator/rom_ext:rom_ext_boot_services_unittest
 
 # CE: variable-sized object may not be initialized
 # //sw/device/lib/crypto/impl:keyblob_unittest

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_services_unittest.cc
@@ -252,7 +252,11 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVer) {
   EXPECT_CALL(mock_manifest_, SpxSignature).WillOnce(Return(kErrorOk));
 
   EXPECT_CALL(mock_rnd_, Uint32);
-  EXPECT_CALL(mock_hmac_, sha256_init);
+
+  // EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_hmac_, sha256_configure);
+  EXPECT_CALL(mock_hmac_, sha256_start);
+
   EXPECT_CALL(mock_lifecycle_, DeviceId);
   EXPECT_CALL(mock_otp_, read32);
   EXPECT_CALL(mock_otp_, read32);
@@ -261,7 +265,9 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVer) {
   EXPECT_CALL(mock_manifest_, DigestRegion);
   EXPECT_CALL(mock_hmac_, sha256_update);
   EXPECT_CALL(mock_hmac_, sha256_process);
-  EXPECT_CALL(mock_hmac_, sha256_final);
+
+  // EXPECT_CALL(mock_hmac_, sha256_final);
+  EXPECT_CALL(mock_hmac_, sha256_final_truncated);
 
   EXPECT_CALL(mock_owner_verify_, verify).WillOnce(Return(kErrorOk));
 
@@ -272,7 +278,11 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVer) {
   EXPECT_CALL(mock_manifest_, SpxSignature).WillOnce(Return(kErrorOk));
 
   EXPECT_CALL(mock_rnd_, Uint32);
-  EXPECT_CALL(mock_hmac_, sha256_init);
+
+  // EXPECT_CALL(mock_hmac_, sha256_init);
+  EXPECT_CALL(mock_hmac_, sha256_configure);
+  EXPECT_CALL(mock_hmac_, sha256_start);
+
   EXPECT_CALL(mock_lifecycle_, DeviceId);
   EXPECT_CALL(mock_otp_, read32);
   EXPECT_CALL(mock_otp_, read32);
@@ -281,7 +291,9 @@ TEST_F(RomExtBootServicesTest, BootSvcMinBl0SecVer) {
   EXPECT_CALL(mock_manifest_, DigestRegion);
   EXPECT_CALL(mock_hmac_, sha256_update);
   EXPECT_CALL(mock_hmac_, sha256_process);
-  EXPECT_CALL(mock_hmac_, sha256_final);
+
+  // EXPECT_CALL(mock_hmac_, sha256_final);
+  EXPECT_CALL(mock_hmac_, sha256_final_truncated);
 
   EXPECT_CALL(mock_owner_verify_, verify).WillOnce(Return(kErrorOk));
 
@@ -318,7 +330,8 @@ TEST_F(RomExtBootServicesTest, BootSvcOwnershipUnlock) {
   boot_svc_msg.ownership_unlock_req.signature = {{100, 101, 102, 103, 104, 105,
                                                   106, 107, 108, 109, 110, 111,
                                                   112, 113, 114, 115}};
-
+  memset(&boot_svc_msg.ownership_unlock_req.din, 0,
+         sizeof(boot_svc_msg.ownership_unlock_req.din));
   EXPECT_CALL(mock_hmac_, sha256)
       .WillOnce(SetArgPointee<2>(hmac_digest_t{0x1234}));
 


### PR DESCRIPTION
The `hmac_sha256_init()` and `hmac_sha256_final()` functions are defined as `static inline` in their header in this coverage repo. This causes them to be inlined by the compiler, making them impossible to mock with gMock. This change updates the tests to mock the functions that are called inside `hmac_sha256_init()` and `hmac_sha256_final()` instead.

The `BootSvcOwnershipUnlock` tests were failing with the LLVM toolchain used for coverage builds. This was because the
`boot_svc_msg.ownership_unlock_req.din` field was uninitialized, but the tests implicitly assumed it was zero. This change explicitly initializes `din` to zero to fix this test.