### PR TITLE
[cov] rename slot_addresses to slot_spec

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -106,7 +106,7 @@ fpga_cw310(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
     test_cmd = "testing-not-supported",
 
     param = {
@@ -173,7 +173,7 @@ sim_qemu(
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
 )
 
 sim_qemu(
@@ -330,7 +330,7 @@ fpga_cw305(
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
     test_cmd = "testing-not-supported",
 )
 
@@ -364,7 +364,7 @@ fpga_cw340(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
     test_cmd = "testing-not-supported",
 )
 
@@ -551,7 +551,7 @@ silicon(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
     },
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
     test_cmd = """
         --exec="transport init"
         --exec="bootstrap --clear-uart=true {firmware}"
@@ -593,7 +593,7 @@ silicon(
         "//signing:test_keys": "//sw/device/silicon_creator/rom_ext/sival:rom_ext_dice_x509_fake_slot_a",
         "//conditions:default": "//sw/device/silicon_creator/rom_ext/sival/binaries:rom_ext_dice_x509_prod",
     }),
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
     test_cmd = """
         --exec="transport init"
         --exec="bootstrap --clear-uart=true {firmware}"
@@ -619,7 +619,7 @@ sim_verilator(
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
     test_cmd = "testing-not-supported",
 )
 
@@ -683,7 +683,7 @@ sim_dv(
     otp_mmap = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
     otp_seed = "//hw/ip/otp_ctrl/data:otp_seed",
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-    slot_addresses = EARLGREY_SLOTS,
+    slot_spec = EARLGREY_SLOTS,
 )
 
 sim_dv(

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -35,7 +35,7 @@ _FIELDS = {
     "rom_scramble_config": ("file.rom_scramble_config", False),
     "openocd": ("attr.openocd", False),
     "openocd_adapter_config": ("attr.openocd_adapter_config", False),
-    "slot_addresses": ("attr.slot_addresses", False),
+    "slot_spec": ("attr.slot_spec", False),
 }
 
 ExecEnvInfo = provider(
@@ -157,8 +157,8 @@ def exec_env_common_attrs(**kwargs):
             allow_files = True,
             doc = "Instrumented ROM image to use in this environment",
         ),
-        "slot_addresses": attr.string_dict(
-            default = kwargs.get("slot_addresses", {}),
+        "slot_spec": attr.string_dict(
+            default = kwargs.get("slot_spec", {}),
             doc = "Firmware slot addresses to use in this environment",
         ),
         "otp": attr.label(
@@ -413,10 +413,10 @@ def common_test_setup(ctx, exec_env, firmware):
         data_files += get_files(jtag_data)
         param["jtag_test_cmd"] = jtag_test_cmd
 
-    # Update actual slot addresses
-    slot_addresses = dict(exec_env.slot_addresses)
-    slot_addresses.update(ctx.attr.slot_addresses)
-    action_param.update(slot_addresses)
-    param.update(slot_addresses)
+    # Update the actual firmware slot spec
+    slot_spec = dict(exec_env.slot_spec)
+    slot_spec.update(ctx.attr.slot_spec)
+    action_param.update(slot_spec)
+    param.update(slot_spec)
 
     return test_harness, data_labels, data_files, param, action_param

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -158,6 +158,7 @@ def _test_dispatch(ctx, exec_env, firmware):
     if "instrumented_rom" in action_param:
         assemble = "{instrumented_rom}@{instrumented_rom_slot}"
         for _ in range(10):
+          # Recursive evaluation of the assemble spec
           assemble = assemble.format(**action_param)
         assemble = ctx.expand_location(assemble, data_labels)
         image = assemble_for_test(


### PR DESCRIPTION
The "slot_addresses" list does not only contain the "addresses", but also sizes.

Rename it to "slot_spec".