### PR TITLE
[cov] Refactor instrumented ROM support

### DIFF
--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -483,14 +483,7 @@ fpga_cw340(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{firmware}@{rom_ext_slot_a} {instrumented_rom}@{instrumented_rom_slot}",
     },
-    rom = "//sw/device/lib/testing/test_rom:test_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    rom = "//sw/device/lib/testing/test_rom:instrumented_rom_loader",
 )
 
 # FPGA configuration used to emulate silicon targets. This rule can be used by
@@ -525,14 +518,7 @@ fpga_cw340(
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{firmware}@{rom_ext_slot_a} {instrumented_rom}@{instrumented_rom_slot}",
     },
-    rom = "//sw/device/lib/testing/test_rom:test_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    rom = "//sw/device/lib/testing/test_rom:instrumented_rom_loader",
 )
 
 # FPGA configuration used to emulate silicon targets containing a `rom_ext`

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -14,6 +14,7 @@ load(
 )
 load(
     "//rules/opentitan:defs.bzl",
+    "CLEAR_TEST_CMD",
     "DEFAULT_TEST_FAILURE_MSG",
     "DEFAULT_TEST_SUCCESS_MSG",
     "fpga_cw305",
@@ -86,6 +87,11 @@ fpga_cw310(
         "//sw/device/lib/arch:fpga_cw310",
     ],
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
+    param = {
+        "interface": "cw310",
+        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
+        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+    },
     rom_scramble_config = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
     slot_spec = EARLGREY_SLOTS,
     test_cmd = "testing-not-supported",
@@ -98,6 +104,7 @@ fpga_cw310(
         "--rcfile=",
         "--logging=info",
         "--interface={interface}",
+        "--drop-reset",
     ] + select({
         "//ci:lowrisc_fpga_cw310": ["--uarts=/dev/ttyACM_CW310_1,/dev/ttyACM_CW310_0"],
         "//conditions:default": [],
@@ -109,18 +116,10 @@ fpga_cw310(
     openocd_adapter_config = "//third_party/openocd:jtag_olimex_cfg",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
     param = {
-        "interface": "cw310",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "testopt_bootstrap": "True",
     },
     rom = "//sw/device/lib/testing/test_rom:test_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    test_cmd = CLEAR_TEST_CMD,
 )
 
 fpga_cw310(
@@ -238,9 +237,6 @@ fpga_cw310(
     manifest = "//sw/device/silicon_owner:manifest",
     otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
     param = {
-        "interface": "cw310",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
     },
     rom = "//sw/device/silicon_creator/rom:mask_rom",
@@ -257,6 +253,7 @@ fpga_cw310(
         "--rcfile=",
         "--logging=info",
         "--interface={interface}",
+        "--drop-reset",
     ],
     base = ":fpga_cw310",
     base_bitstream = "//hw/bitstream/hyperdebug:bitstream",
@@ -267,17 +264,10 @@ fpga_cw310(
     otp = "//hw/ip/otp_ctrl/data:img_rma",
     param = {
         "interface": "hyper310",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
+        "testopt_bootstrap": "True",
     },
     rom = "//sw/device/silicon_creator/rom:mask_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    test_cmd = CLEAR_TEST_CMD,
 )
 
 fpga_cw310(
@@ -294,9 +284,6 @@ fpga_cw310(
     manifest = "//sw/device/silicon_owner:manifest",
     otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
     param = {
-        "interface": "hyper310",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
     },
     rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
@@ -375,6 +362,7 @@ fpga_cw340(
         "--rcfile=",
         "--logging=info",
         "--interface={interface}",
+        "--drop-reset",
     ] + select({
         "//ci:lowrisc_fpga_cw340": ["--uarts=/dev/ttyACM_CW340_1,/dev/ttyACM_CW340_0"],
         "//conditions:default": [],
@@ -404,14 +392,11 @@ fpga_cw340(
     exec_env = "fpga_cw340_test_rom",
     mmi = "//hw/bitstream/cw340:mmi",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
+    param = {
+        "testopt_bootstrap": "True",
+    },
     rom = "//sw/device/lib/testing/test_rom:test_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    test_cmd = CLEAR_TEST_CMD,
 )
 
 fpga_cw340(
@@ -424,14 +409,11 @@ fpga_cw340(
     manifest = "//sw/device/silicon_creator/rom_ext:manifest",
     mmi = "//hw/bitstream/cw340:mmi",
     otp = "//hw/ip/otp_ctrl/data:img_rma",
+    param = {
+        "testopt_bootstrap": "True",
+    },
     rom = "//sw/device/silicon_creator/rom:mask_rom",
-    test_cmd = """
-        --exec="transport init"
-        --exec="fpga load-bitstream {bitstream}"
-        --exec="bootstrap --clear-uart=true {firmware}"
-        --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-        no-op
-    """,
+    test_cmd = CLEAR_TEST_CMD,
 )
 
 fpga_cw340(
@@ -452,9 +434,6 @@ fpga_cw340(
     manifest = "//sw/device/silicon_owner:manifest",
     otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
     param = {
-        "interface": "hyper340",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a}",
     },
     rom_ext = select({

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -454,14 +454,8 @@ fpga_cw340(
     testonly = True,
     base = ":fpga_cw340_rom_with_fake_keys",
     exec_env = "fpga_cw340_instrumented_rom",
-    instrumented_rom = "//sw/device/silicon_creator/rom:instrumented_mask_rom",
+    instrumented_rom = "//sw/device/silicon_creator/rom:instrumented_rom_image",
     otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
-    param = {
-        "interface": "hyper340",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "assemble": "{firmware}@{rom_ext_slot_a} {instrumented_rom}@{instrumented_rom_slot}",
-    },
     rom = "//sw/device/lib/testing/test_rom:instrumented_rom_loader",
 )
 
@@ -490,13 +484,7 @@ fpga_cw340(
     testonly = True,
     base = ":fpga_cw340_sival",
     exec_env = "fpga_cw340_instrumented_rom_prod",
-    instrumented_rom = "//sw/device/silicon_creator/rom:instrumented_mask_rom",
-    param = {
-        "interface": "hyper340",
-        "exit_success": DEFAULT_TEST_SUCCESS_MSG,
-        "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "assemble": "{firmware}@{rom_ext_slot_a} {instrumented_rom}@{instrumented_rom_slot}",
-    },
+    instrumented_rom = "//sw/device/silicon_creator/rom:instrumented_rom_image",
     rom = "//sw/device/lib/testing/test_rom:instrumented_rom_loader",
 )
 

--- a/rules/opentitan/cc.bzl
+++ b/rules/opentitan/cc.bzl
@@ -578,7 +578,16 @@ def _opentitan_binary_assemble_impl(ctx):
         result.append(exec_env_provider(default = bin, kind = "flash", vmem = vmem))
         assembled_bins.append(bin)
         assembled_bins.append(vmem)
-    return result + [DefaultInfo(files = depset(assembled_bins))]
+
+    # Propagate runfiles
+    runfiles = ctx.runfiles()
+    for binary in ctx.attr.bins.keys():
+        runfiles = runfiles.merge(binary[DefaultInfo].default_runfiles)
+        if ctx.var.get("ot_coverage_enabled", "false") == "true":
+            # Add elf files to runfiles for coverage
+            runfiles = runfiles.merge(ctx.runfiles(binary.files.to_list()))
+
+    return result + [DefaultInfo(files = depset(assembled_bins), runfiles = runfiles)]
 
 opentitan_binary_assemble = rule(
     implementation = _opentitan_binary_assemble_impl,

--- a/rules/opentitan/exec_env.bzl
+++ b/rules/opentitan/exec_env.bzl
@@ -38,6 +38,10 @@ _FIELDS = {
     "slot_spec": ("attr.slot_spec", False),
 }
 
+_NESTED_FIELDS = {
+    "param": True,
+}
+
 ExecEnvInfo = provider(
     doc = "Execution Environment Info",
 )
@@ -86,14 +90,20 @@ def exec_env_as_dict(ctx):
     }
     for field, (path, required) in _FIELDS.items():
         val = getattr_path(ctx, path)
-        if not val and base:
+        if _NESTED_FIELDS.get(field, False) and base:
+            merged_val = dict(getattr(base, field) or {})
+            merged_val.update(val or {})
+            val = merged_val
+        elif not val and base:
             # If the value doesn't exist in the context object, get the value
             # from the base provider (if present).
             val = getattr(base, field)
 
         if required and not val:
             fail("No value for required field {} in {}".format(field, ctx.attr.name))
+
         result[field] = val
+
     return result
 
 def exec_env_common_attrs(**kwargs):

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -191,6 +191,12 @@ def _get_test_commands(ctx, param, exec_env):
     test_cleanup_cmd = []
     if _get_bool(param, "testopt_clear_after_test"):
         test_cleanup_cmd.append('--exec="fpga clear-bitstream"')
+    elif "instrumented_rom" in param:
+        # Cleanup instrumented ROM magic bytes.
+        test_cleanup_cmd.extend([
+            '--exec="transport init"',
+            '--exec="fpga clear-instrumented-rom --clear-uart=true --slot={instrumented_rom_slot}"',
+        ])
 
     test_cleanup_cmd = "\n".join(test_cleanup_cmd)
 

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -29,12 +29,23 @@ load(
 load("//rules/opentitan:toolchain.bzl", "LOCALTOOLS_TOOLCHAIN")
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
+_TEST_COMMANDS = """
+TEST_SETUP_CMD=({test_setup_cmd})
+TEST_CMD=({test_cmd})
+TEST_CLEANUP_CMD=({test_cleanup_cmd})
+POST_TEST_CMD=({post_test_cmd})
+"""
+
 _TEST_SCRIPT = """#!/bin/bash
 set -e
 
+{test_commands}
+
+export RUST_BACKTRACE=1
+
 function cleanup {{
-  echo "cleanup: {post_test_harness} {post_test_cmd}"
-  {post_test_harness} {post_test_cmd}
+  {post_test_harness} "${{POST_TEST_CMD[@]}}"
+  {opentitantool} {args} "${{TEST_CLEANUP_CMD[@]}}" no-op
 }}
 
 # Bazel will send a SIGTERM when the timeout expires and will
@@ -43,15 +54,21 @@ function cleanup {{
 # on timeout.
 trap cleanup EXIT
 
-TEST_CMD=({test_cmd})
+set -x
+
+{opentitantool} {args} "${{TEST_SETUP_CMD[@]}}" no-op
+{test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+"""
+
+_QQ_SCRIPT = """#!/bin/bash
+set -e
+
+TEST_SCRIPT=({test_script})
 if command -v qq >/dev/null 2>&1; then
-  echo Invoking test: qq {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
-  echo
   echo Wait until the FPGA becomes available...
-  RUST_BACKTRACE=1 qq {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+  qq "${{TEST_SCRIPT[@]}}" "$@"
 else
-  echo Invoking test: {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
-  RUST_BACKTRACE=1 {test_harness} {args} "$@" "${{TEST_CMD[@]}}"
+  "${{TEST_SCRIPT[@]}}" "$@"
 fi
 """
 
@@ -113,6 +130,75 @@ def _transform(ctx, exec_env, name, elf, binary, signed_bin, disassembly, mapfil
         "hashfile": hashfile,
     }
 
+def _get_bool(param, name, default = "False"):
+    value = param.get(name, default).lower()
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    fail("Invalid boolean value {} for field {}".format(name, value))
+
+def _get_test_commands(ctx, param, exec_env):
+    """Process the testopt flags to generate test commands.
+
+    Test Option Param Fields:
+      testopt_bootstrap: If True, bootstrap the firmware before test.
+      testopt_clear_before_test: If True, clear the bitstream before test.
+      testopt_clear_after_test: If True, clear the bitstream after test.
+      testopt_needs_jtag: If True, tests require JTAG access.
+
+    Common Param Fields:
+      exit_success: The console output for test success.
+      exit_failure: The console output for test failure.
+      jtag_test_cmd: The JTAG test command (if testopt_needs_jtag is True).
+      bitstream: The bitstream to load before test.
+      firmware: The firmware to load with bootstrap.
+
+    Args:
+      ctx: The rule context.
+      param: A dictionary of key-value test parameters.
+      exec_env: The ExecEnvInfo for this environment.
+
+    Returns:
+      (string, string) A tuple of (test_setup_cmd, test_cleanup_cmd), which are
+      opentitantool arguments.
+    """
+
+    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
+
+    # If no test_cmd or custom harness is specified, run the default console harness.
+    if not test_cmd.strip() and not ctx.attr.test_harness:
+        test_cmd = """
+          console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'
+        """
+
+    if _get_bool(param, "testopt_needs_jtag"):
+        test_cmd = " {jtag_test_cmd} " + test_cmd
+
+    # Construct the opentitantool test setup commands
+    test_setup_cmd = ['--exec="transport init"']
+    if _get_bool(param, "testopt_clear_before_test"):
+        test_setup_cmd.append('--exec="fpga clear-bitstream"')
+    if "bitstream" in param:
+        test_setup_cmd.append('--exec="fpga load-bitstream {bitstream}"')
+    if _get_bool(param, "testopt_bootstrap") and "firmware" in param:
+        test_setup_cmd.append('--exec="bootstrap --leave-in-reset --clear-uart=true {firmware}"')
+    test_setup_cmd = "\n".join(test_setup_cmd)
+
+    # Construct the opentitantool test cleanup commands
+    test_cleanup_cmd = []
+    if _get_bool(param, "testopt_clear_after_test"):
+        test_cleanup_cmd.append('--exec="fpga clear-bitstream"')
+
+    test_cleanup_cmd = "\n".join(test_cleanup_cmd)
+
+    return _TEST_COMMANDS.format(
+        test_setup_cmd = test_setup_cmd,
+        test_cmd = test_cmd,
+        test_cleanup_cmd = test_cleanup_cmd,
+        post_test_cmd = ctx.attr.post_test_cmd,
+    )
+
 def _test_dispatch(ctx, exec_env, firmware):
     """Dispatch a test for the fpga_cw3{05,10,40} environment.
 
@@ -157,9 +243,7 @@ def _test_dispatch(ctx, exec_env, firmware):
 
     # FIXME: maybe splice a bitstream here
 
-    # Perform all relevant substitutions on the test_cmd.
-    test_cmd = get_fallback(ctx, "attr.test_cmd", exec_env)
-
+    """
     if "instrumented_rom" in action_param:
         assemble = "{instrumented_rom}@{instrumented_rom_slot}"
         for _ in range(10):
@@ -189,36 +273,52 @@ def _test_dispatch(ctx, exec_env, firmware):
         if idx != -1:
             test_cmd_list.insert(idx + 1, '--exec="bootstrap --clear-uart=true {ins_rom_image}"')
             test_cmd = "\n".join(test_cmd_list)
-
-    test_cmd = test_cmd.format(**param)
-    test_cmd = ctx.expand_location(test_cmd, data_labels)
+    """
 
     # Get the pre-test_cmd args.
     args = get_fallback(ctx, "attr.args", exec_env)
     args = " ".join(args).format(**param)
     args = ctx.expand_location(args, data_labels)
 
-    # Construct the test script
-    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
+    # Perform all relevant substitutions on the test_cmd.
+    test_commands = _get_test_commands(ctx, param, exec_env)
+    test_commands = test_commands.format(**param)
+    test_commands = ctx.expand_location(test_commands, data_labels)
+
+    # Construct the post test commands
     post_test_harness_path = ctx.executable.post_test_harness
-    post_test_cmd = ctx.attr.post_test_cmd.format(**param)
     if post_test_harness_path != None:
         data_files.append(post_test_harness_path)
         post_test_harness_path = post_test_harness_path.short_path
     else:
         post_test_harness_path = ""
+
+    # Construct the test script
+    script = ctx.actions.declare_file(ctx.attr.name + ".bash")
     ctx.actions.write(
         script,
         _TEST_SCRIPT.format(
             test_harness = test_harness.executable.short_path,
             args = args,
-            test_cmd = test_cmd,
+            test_commands = test_commands,
             post_test_harness = post_test_harness_path,
-            post_test_cmd = post_test_cmd,
+            opentitantool = exec_env._opentitantool.executable.short_path,
         ),
         is_executable = True,
     )
-    return script, data_files
+    data_files.append(exec_env._opentitantool.executable)
+
+    qq_script = ctx.actions.declare_file(ctx.attr.name + ".qq.bash")
+    ctx.actions.write(
+        qq_script,
+        _QQ_SCRIPT.format(
+            test_script = script.short_path,
+        ),
+        is_executable = True,
+    )
+    data_files.append(script)
+
+    return qq_script, data_files
 
 def _fpga_cw310(ctx):
     fields = exec_env_as_dict(ctx)
@@ -279,6 +379,8 @@ def fpga_params(
         test_cmd = "",
         data = [],
         defines = [],
+        post_test_cmd = "",
+        post_test_harness = None,
         **kwargs):
     """A macro to create CW3{05,10,40} parameters for OpenTitan tests.
 
@@ -305,8 +407,10 @@ def fpga_params(
         bitstream = "@//hw/bitstream/universal:splice"
 
     # Clear bitstream after the test if it changes the OTP.
-    post_test_harness = "//sw/host/opentitantool" if changes_otp else None
-    post_test_cmd = "--rcfile= --logging=info --interface={interface} fpga clear-bitstream" if changes_otp else ""
+    if changes_otp:
+        kwargs["testopt_clear_after_test"] = "True"
+    if needs_jtag:
+        kwargs["testopt_needs_jtag"] = "True"
     return struct(
         # We do not yet know what FPGA platform the test will target (as this is
         # defined in the execution environment), so we do not know that tag
@@ -321,11 +425,7 @@ def fpga_params(
         otp = otp,
         bitstream = bitstream,
         needs_jtag = needs_jtag,
-        test_cmd = ("""
-            --bitstream={bitstream}
-        """ if test_harness != None else "") + ("""
-            {jtag_test_cmd}
-        """ if needs_jtag else "") + test_cmd,
+        test_cmd = test_cmd,
         data = data,
         param = kwargs,
         post_test_cmd = post_test_cmd,

--- a/rules/opentitan/fpga.bzl
+++ b/rules/opentitan/fpga.bzl
@@ -181,6 +181,8 @@ def _get_test_commands(ctx, param, exec_env):
         test_setup_cmd.append('--exec="fpga clear-bitstream"')
     if "bitstream" in param:
         test_setup_cmd.append('--exec="fpga load-bitstream {bitstream}"')
+    if "instrumented_rom" in param:
+        test_setup_cmd.append('--exec="bootstrap --leave-in-reset --clear-uart=true {instrumented_rom}"')
     if _get_bool(param, "testopt_bootstrap") and "firmware" in param:
         test_setup_cmd.append('--exec="bootstrap --leave-in-reset --clear-uart=true {firmware}"')
     test_setup_cmd = "\n".join(test_setup_cmd)
@@ -224,8 +226,6 @@ def _test_dispatch(ctx, exec_env, firmware):
     # image.
     if "assemble" in param:
         assemble = param.get("assemble")
-        if "instrumented_rom" in action_param and "instrumented_rom" not in assemble:
-            assemble += " {instrumented_rom}@{instrumented_rom_slot}"
         assemble = recursive_format(assemble, action_param)
         assemble = ctx.expand_location(assemble, data_labels)
         image = assemble_for_test(
@@ -238,42 +238,8 @@ def _test_dispatch(ctx, exec_env, firmware):
         param["firmware"] = image.short_path
         action_param["firmware"] = image.path
         data_files.append(image)
-    elif "instrumented_rom" in action_param:
-        fail("Got instrumented rom without assemble spec")
 
     # FIXME: maybe splice a bitstream here
-
-    """
-    if "instrumented_rom" in action_param:
-        assemble = "{instrumented_rom}@{instrumented_rom_slot}"
-        for _ in range(10):
-            # Recursive evaluation of the assemble spec
-            assemble = assemble.format(**action_param)
-        assemble = ctx.expand_location(assemble, data_labels)
-        image = assemble_for_test(
-            ctx,
-            name = ctx.attr.name + "_ins_rom",
-            spec = assemble.strip().split(" "),
-            data_files = data_files,
-            opentitantool = exec_env._opentitantool,
-        )
-        param["ins_rom_image"] = image.short_path
-        action_param["ins_rom_image"] = image.path
-        data_files.append(image)
-
-        test_cmd_list = test_cmd.split("\n")
-
-        def find_bitstream_idx():
-            for i, e in list(enumerate(test_cmd_list)):
-                if "load-bitstream" in e:
-                    return i
-            return -1
-
-        idx = find_bitstream_idx()
-        if idx != -1:
-            test_cmd_list.insert(idx + 1, '--exec="bootstrap --clear-uart=true {ins_rom_image}"')
-            test_cmd = "\n".join(test_cmd_list)
-    """
 
     # Get the pre-test_cmd args.
     args = get_fallback(ctx, "attr.args", exec_env)

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -358,9 +358,6 @@ opentitan_test(
     fpga = fpga_params(
         flow_control_message = _FLOW_CONTROL_MESSAGE,
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success=WAIT --exit-failure=PASS|FAIL --flow-control"
             console
             --flow-control

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -25,6 +25,43 @@ ld_library(
     ],
 )
 
+cc_library(
+    name = "instrumented_rom_loader_enabled",
+    srcs = ["instrumented_rom_loader_enabled.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/ip/sram_ctrl/data:sram_ctrl_c_regs",
+        "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:macros",
+    ],
+)
+
+cc_library(
+    name = "instrumented_rom_loader_disabled",
+    srcs = ["instrumented_rom_loader_disabled.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+)
+
+opentitan_binary(
+    name = "instrumented_rom_loader",
+    collect_code_coverage = 0,
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310",
+        "//hw/top_earlgrey:fpga_cw305",
+        "//hw/top_earlgrey:fpga_cw340",
+        "//hw/top_earlgrey:sim_dv_base",
+        "//hw/top_earlgrey:sim_qemu_base",
+        "//hw/top_earlgrey:sim_verilator_base",
+    ],
+    kind = "rom",
+    linker_script = ":linker_script",
+    deps = [
+        ":instrumented_rom_loader_enabled",
+        ":test_rom_lib",
+    ],
+)
+
 opentitan_binary(
     name = "test_rom",
     collect_code_coverage = 0,
@@ -39,6 +76,7 @@ opentitan_binary(
     kind = "rom",
     linker_script = ":linker_script",
     deps = [
+        ":instrumented_rom_loader_disabled",
         ":test_rom_lib",
     ],
 )

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -35,12 +35,14 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
     ],
+    alwayslink = True,
 )
 
 cc_library(
     name = "instrumented_rom_loader_disabled",
     srcs = ["instrumented_rom_loader_disabled.S"],
     target_compatible_with = [OPENTITAN_CPU],
+    alwayslink = True,
 )
 
 opentitan_binary(

--- a/sw/device/lib/testing/test_rom/instrumented_rom_loader_disabled.S
+++ b/sw/device/lib/testing/test_rom/instrumented_rom_loader_disabled.S
@@ -1,0 +1,15 @@
+/**
+ * Skip instrumented ROM loader.
+ *
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .crt, "ax"
+  .balign 4
+  .global _try_instrumented_rom
+  .type _try_instrumented_rom, @function
+
+_try_instrumented_rom:
+  ret
+  .size _try_instrumented_rom, .-_try_instrumented_rom

--- a/sw/device/lib/testing/test_rom/instrumented_rom_loader_enabled.S
+++ b/sw/device/lib/testing/test_rom/instrumented_rom_loader_enabled.S
@@ -1,0 +1,113 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "sw/device/lib/base/macros.h"
+#include "sram_ctrl_regs.h"
+#include "flash_ctrl_regs.h"
+
+/**
+ * Instrumented ROM loader.
+ *
+ * The loader checks if the instrumented ROM is present on flash, and if so,
+ * it will configure the hardware to allow its execution. Then it jumps to the
+ * instrumented ROM. Otherwise, it will fall back to the default test ROM by
+ * just returning.
+ */
+
+  // NOTE: The "ax" flag below is necessary to ensure that this section
+  // is allocated executable space in ROM by the linker.
+  .section .crt, "ax"
+  .balign 4
+  .global _try_instrumented_rom
+  .type _try_instrumented_rom, @function
+
+_try_instrumented_rom:
+  /**
+   * Unlock ePMP for Flash access
+   */
+  // Remove address space protections by configuring entry 15 as
+  // read-write-execute for the entire address space and then clearing
+  // all other entries.
+  // NOTE: This should happen before attemting to access any address outside
+  // the initial ePMP RX region at reset, e.g. `kDeviceType` which is in
+  // .rodata.
+  li   t0, (0x9f << 24) // Locked NAPOT read-write-execute.
+  csrw pmpcfg3, t0
+  li   t0, 0x7fffffff   // NAPOT encoded region covering entire 34-bit address space.
+  csrw pmpaddr15, t0
+
+  // Configure `pmpcfg0` in test ROM to enable instrumented ROM execution.
+  // Without this configuration, the instrumented ROM can not be executed due to
+  // ePMP reconfiguration in `rom_epmp_init`.
+  li   t0, (0x8f << 8) // Locked TOR read-write-execute.
+  csrw pmpcfg0, t0
+  li   t0, 0
+  csrw pmpaddr0, t0
+  li   t0, 0x10000000 // TOR encoded region convering entire eFlash address space.
+  csrw pmpaddr1, t0
+
+  csrw pmpcfg1, zero
+  csrw pmpcfg2, zero
+
+  /**
+   * Reset flash protection on the instrumented ROM region
+   */
+  li    t1, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
+
+  // t0 = ( ((size / 2048) << 9) | (offset / 2048) )
+  la    t0, _instrumented_rom_size
+  srli  t0, t0, 11 // Divide by 2048 (2^11)
+  slli  t0, t0, 9  // Shift to bit 9 for size field
+
+  la    t3, _instrumented_rom_slot
+  srli  t3, t3, 11 // Divide by 2048 (2^11)
+  or    t0, t0, t3
+  sw    t0, FLASH_CTRL_MP_REGION_7_REG_OFFSET(t1)
+
+  // Enabled: Read / Write / Erase / Enable
+  // Disabled: High Endurance / Scramble / ECC
+  li t0, 0x9996666
+  sw    t0, FLASH_CTRL_MP_REGION_CFG_7_REG_OFFSET(t1)
+
+  /**
+   * Check if instrumented ROM is presented
+   */
+  la a0, (_instrumented_rom_slot + TOP_EARLGREY_EFLASH_BASE_ADDR)
+
+  // Continue test rom if the magic bytes are not 'IROM'
+  // The magic bytes is defined in the `instrumented_header.c`.
+  lw t0, 0x180(a0)
+  li t1, 0x4d4f5249
+  beq t0, t1, .L_boot_instrumented_rom
+  ret
+
+.L_boot_instrumented_rom:
+  /**
+   * Initialize the hardware for running instrumented ROM
+   */
+  // Initialize main memory (main SRAM).
+  li    t1, TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR
+  li    t0, (1 << SRAM_CTRL_CTRL_INIT_BIT)
+  sw    t0, SRAM_CTRL_CTRL_REG_OFFSET(t1)
+
+  // Set exception/interrupt handlers.
+  //
+  // Note: the increment just sets the low bits to 0b01 which is the vectored
+  // mode setting.
+  addi  t0, a0, 1
+  csrw mtvec, t0
+
+  // Unlock execution for code on the flash
+  li   a3, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
+  li   t1, 0xa26a38f7
+  sw   t1, FLASH_CTRL_EXEC_REG_OFFSET(a3)
+
+  /**
+   * Jump to instrumented ROM
+   */
+  jr 0x80(a0)
+  unimp
+
+  .size _try_instrumented_rom, .-_try_instrumented_rom

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -89,64 +89,6 @@ _test_rom_interrupt_vector:
   .type _reset_start, @function
 
 _reset_start:
-#ifdef OT_COVERAGE_ENABLED
-  // Remove address space protections by configuring entry 15 as
-  // read-write-execute for the entire address space and then clearing
-  // all other entries.
-  // NOTE: This should happen before attemting to access any address outside
-  // the initial ePMP RX region at reset, e.g. `kDeviceType` which is in
-  // .rodata.
-  li   t0, (0x9f << 24) // Locked NAPOT read-write-execute.
-  csrw pmpcfg3, t0
-  li   t0, 0x7fffffff   // NAPOT encoded region covering entire 34-bit address space.
-  csrw pmpaddr15, t0
-
-  // Configure `pmpcfg0` in test ROM to enable instrumented ROM execution.
-  // Without this configuration, the instrumented ROM can not be executed due to
-  // ePMP reconfiguration in `rom_epmp_init`.
-  li   t0, (0x8f << 8) // Locked TOR read-write-execute.
-  csrw pmpcfg0, t0
-  li   t0, 0
-  csrw pmpaddr0, t0
-  li   t0, 0x10000000 // TOR encoded region convering entire eFlash address space.
-  csrw pmpaddr1, t0
-
-  csrw pmpcfg1, zero
-  csrw pmpcfg2, zero
-
-  // Check if instrumented ROM is presented
-  la a0, (_instrumented_rom_slot + 0x20000000)
-  lw t0, 0x80(a0)
-
-  // Continue if it's 0 or -1
-  li t1, 0x1
-  add t0, t0, t1
-  bleu t0, t1, continue_test_rom
-
-  // Set up the stack.
-  la sp, _stack_end
-
-  // Initialize main memory (main SRAM).
-  li    t1, TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR
-  li    t0, (1 << SRAM_CTRL_CTRL_INIT_BIT)
-  sw    t0, SRAM_CTRL_CTRL_REG_OFFSET(t1)
-
-  // Set exception/interrupt handlers.
-  //
-  // Note: the increment just sets the low bits to 0b01 which is the vectored
-  // mode setting.
-  addi  t0, a0, 1
-  csrw mtvec, t0
-
-  // Jump to instrumented ROM
-  li   a3, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
-  li   t1, 0xa26a38f7
-  sw   t1, FLASH_CTRL_EXEC_REG_OFFSET(a3)
-  jalr ra, 0x80(a0)
-
-continue_test_rom:
-#endif
-
   // Set up the global pointer. This requires that we disable linker relaxations
   // (or it will be relaxed to `mv gp, gp`).
   .option push
@@ -205,6 +147,8 @@ continue_test_rom:
   .global _start
   .type _start, @function
 _start:
+  call _try_instrumented_rom
+
 #if !OT_IS_ENGLISH_BREAKFAST
   // Check if AST initialization should be skipped.
   li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \

--- a/sw/device/silicon_creator/lib/cert/BUILD
+++ b/sw/device/silicon_creator/lib/cert/BUILD
@@ -211,7 +211,10 @@ cc_library(
 opentitan_test(
     name = "dice_cwt_functest",
     srcs = ["dice_cwt_functest.c"],
-    exec_env = {"//hw/top_earlgrey:fpga_cw310_rom_ext": None},
+    exec_env = {
+        "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
+    },
     deps = [
         ":dice_cwt",
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -968,9 +968,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/usb:silicon_creator_harness",
     ),
     silicon = silicon_params(

--- a/sw/device/silicon_creator/lib/sigverify/sigverify_tests/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/sigverify_tests/BUILD
@@ -31,9 +31,7 @@ opentitan_test(
     fpga = fpga_params(
         timeout = "moderate",
         data = _TEST_VECTORS,
-        test_cmd = """
-                --bootstrap={firmware}
-            """ + _TEST_ARGS,
+        test_cmd = _TEST_ARGS,
         test_harness = "//sw/host/tests/crypto/ecdsa_kat:harness",
     ),
     deps = [

--- a/sw/device/silicon_creator/manuf/base/BUILD
+++ b/sw/device/silicon_creator/manuf/base/BUILD
@@ -147,6 +147,7 @@ opentitan_test(
             --test-sram-elf={sram_cp_provision_functest}
         """,
         test_harness = "//sw/host/tests/manuf/cp_provision_functest",
+        testopt_bootstrap = "False",
     ),
 )
 

--- a/sw/device/silicon_creator/manuf/tests/BUILD
+++ b/sw/device/silicon_creator/manuf/tests/BUILD
@@ -88,12 +88,9 @@ _MANUF_TEST_LOCKED_KEY = None
             needs_jtag = True,
             otp = "//hw/ip/otp_ctrl/data:img_{}".format(lc_state.lower()),
             tags = ["manuf"],
-            test_cmd = (
-                "" if (
-                    (lc_state, lc_val) in _TEST_LOCKED_LC_ITEMS
-                ) else "--bootstrap={firmware}"
-            ) + " --initial-lc-state={lc_state}",
+            test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_scrap",
+            testopt_bootstrap = str((lc_state, lc_val) not in _TEST_LOCKED_LC_ITEMS),
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -129,6 +126,7 @@ opentitan_test(
         otp = "//hw/ip/otp_ctrl/data:img_raw",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_unlock_raw",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -151,6 +149,7 @@ opentitan_test(
         otp = "//hw/ip/otp_ctrl/data:img_raw",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_volatile_unlock_raw",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -191,6 +190,7 @@ opentitan_test(
             tags = ["manuf"],
             test_cmd = "--initial-lc-state={lc_state}",
             test_harness = "//sw/host/tests/manuf/manuf_cp_yield_test",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -262,6 +262,7 @@ cc_library(
             tags = ["manuf"],
             test_cmd = "--elf={firmware}",
             test_harness = "//sw/host/tests/manuf/manuf_sram_program_crc_check",
+            testopt_bootstrap = "False",
         ),
         kind = "ram",
         linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
@@ -360,6 +361,7 @@ opentitan_binary(
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/manuf/manuf_cp_device_info_flash_wr",
+            testopt_bootstrap = "False",
         ),
         spx_key = spx_key_for_lc_state(
             ECDSA_SPX_KEY_STRUCTS,
@@ -440,6 +442,7 @@ opentitan_binary(
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/manuf/manuf_cp_ast_test_execution",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -473,6 +476,7 @@ opentitan_test(
         otp = ":otp_img_otp_ctrl_functest",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/manuf_cp_test_lock",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -501,6 +505,7 @@ opentitan_test(
         otp = ":otp_img_otp_ctrl_functest",
         tags = ["manuf"],
         test_harness = "//sw/host/tests/manuf/otp_ctrl:otp_ctrl",
+        testopt_bootstrap = "False",
     ),
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_c_regs",
@@ -557,9 +562,6 @@ opentitan_test(
     },
     fpga = fpga_params(
         tags = ["manuf"],
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/manuf/manuf_ujson_msg_size",
     ),
     deps = [
@@ -579,9 +581,6 @@ opentitan_test(
     },
     fpga = fpga_params(
         tags = ["manuf"],
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/manuf/manuf_ujson_msg_padding",
     ),
     deps = [

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -79,24 +79,20 @@ ld_library(
 )
 
 ld_library(
-    name = "ld_rom",
+    name = "linker_script",
     script = "rom.ld",
     deps = [
         ":ld_common",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
-        #"//sw/device:info_sections",
-        #"//sw/device/lib/coverage:coverage_sections",
     ],
 )
 
 ld_library(
-    name = "ld_instrumented_rom",
+    name = "linker_script_instrumented",
     script = "instrumented_rom.ld",
     deps = [
         ":ld_common",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
-        #"//sw/device:info_sections",
-        #"//sw/device/lib/coverage:coverage_sections",
     ],
 )
 
@@ -130,7 +126,7 @@ cc_library(
 )
 
 asm_library_with_coverage(
-    name = "common_mask_rom_lib",
+    name = "mask_rom_lib",
     srcs = ["rom_start.S"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
@@ -158,26 +154,6 @@ asm_library_with_coverage(
         "//sw/device/lib/coverage:api_asm",
         "//sw/device/lib/coverage:uart_runtime",
         "//sw/device/silicon_creator/lib/base:chip",
-    ],
-    alwayslink = True,
-)
-
-cc_library(
-    name = "mask_rom_lib",
-    target_compatible_with = [OPENTITAN_CPU],
-    deps = [
-        ":common_mask_rom_lib",
-        ":ld_rom",
-    ],
-    alwayslink = True,
-)
-
-cc_library(
-    name = "instrumented_rom_lib",
-    target_compatible_with = [OPENTITAN_CPU],
-    deps = [
-        ":common_mask_rom_lib",
-        ":ld_instrumented_rom",
     ],
     alwayslink = True,
 )
@@ -265,14 +241,24 @@ opentitan_binary(
         "//hw/top_earlgrey:silicon_creator",
     ],
     kind = "rom",
-    linker_script = ":ld_rom",
+    linker_script = ":linker_script",
     deps = [
+        ":linker_script",
         ":mask_rom_lib",
         # We depend on rom_isrs here rather than in mask_rom_lib so that the
         # `rom_exception_handler` symbol remains unresolved and can be supplied
         # by tests such as `rom_epmp_test`.
         ":rom_isrs",
     ],
+)
+
+cc_library(
+    name = "instrumented_header",
+    srcs = ["instrumented_header.c"],
+    deps = [
+        "//sw/device/lib/base:macros",
+    ],
+    alwayslink = True,
 )
 
 opentitan_binary(
@@ -282,10 +268,12 @@ opentitan_binary(
         "//hw/top_earlgrey:fpga_cw340",
         "//hw/top_earlgrey:silicon_creator",
     ],
-    linker_script = ":ld_instrumented_rom",
+    linker_script = ":linker_script_instrumented",
     manifest = "//hw/top_earlgrey:none_manifest",
     deps = [
-        ":instrumented_rom_lib",
+        ":instrumented_header",
+        ":linker_script_instrumented",
+        ":mask_rom_lib",
         # We depend on rom_isrs here rather than in mask_rom_lib so that the
         # `rom_exception_handler` symbol remains unresolved and can be supplied
         # by tests such as `rom_epmp_test`.
@@ -344,7 +332,6 @@ cc_library(
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:csr",
         "//sw/device/lib/base:memory",
-        "//sw/device/lib/coverage:api_asm",
         "//sw/device/silicon_creator/lib:epmp_state",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
@@ -366,7 +353,7 @@ opentitan_test(
         "//hw/top_earlgrey:sim_verilator": None,
     },
     kind = "rom",
-    linker_script = ":ld_rom",
+    linker_script = ":linker_script",
     linkopts = [
         "-Wl,--defsym=rom_test=1",
     ],

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -630,9 +630,6 @@ opentitan_test(
             # This is a manual test.  Run it with:
             #     --test_output=streamed --copt=-DSTACK_UTILIZATION_CHECK
             ###########################################################################'"
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-
             --exec="no-op --info '### Measuring stack utilization for bootstrap slot A'"
             --exec="bootstrap --clear-uart=true --leave-in-bootstrap {good_a}"
             --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='{exit_failure}'"
@@ -674,6 +671,7 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{stack_usage}' --exit-failure='PASS|FAIL'"
             no-op
         """,
+        testopt_bootstrap = "False",
     ),
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,

--- a/sw/device/silicon_creator/rom/BUILD
+++ b/sw/device/silicon_creator/rom/BUILD
@@ -15,6 +15,7 @@ load(
     "opentitan_manual_test",
     "opentitan_test",
 )
+load("//rules/opentitan:cc.bzl", "opentitan_binary_assemble")
 load("//rules/opentitan:legacy.bzl", "legacy_rom_targets")
 load("//rules/coverage:view.bzl", "coverage_view_test")
 load("//rules/coverage:asm.bzl", "asm_library_with_coverage")
@@ -278,6 +279,16 @@ opentitan_binary(
         # `rom_exception_handler` symbol remains unresolved and can be supplied
         # by tests such as `rom_epmp_test`.
         ":rom_isrs",
+    ],
+)
+
+opentitan_binary_assemble(
+    name = "instrumented_rom_image",
+    bins = {
+        ":instrumented_mask_rom": "{instrumented_rom_slot}",
+    },
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw340",
     ],
 )
 

--- a/sw/device/silicon_creator/rom/e2e/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/BUILD
@@ -456,14 +456,7 @@ opentitan_test(
         exit_success = "min_security_version_rom_ext:0(?s:.*)min_security_version_rom_ext:1(?s:.*)" + MSG_TEMPLATE_BFV.format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         # We clear the bitstream to force any subsequent test to load a
         # fresh bitstream and clear all memories (ie: flash-based boot policy).
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            --exec="fpga clear-bitstream\"
-            no-op
-        """,
+        testopt_clear_after_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_creator_slot_a",
     deps = [

--- a/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/bootstrap/BUILD
@@ -78,9 +78,6 @@ opentitan_test(
         changes_otp = True,
         needs_jtag = True,
         otp = "otp_img_bootstrap_rma",
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/rom/e2e_bootstrap_rma",
     ),
     deps = [
@@ -106,6 +103,7 @@ opentitan_test(
         },
         otp = "//hw/ip/otp_ctrl/data:img_bootstrap_disabled",
         test_harness = "//sw/host/tests/rom/e2e_bootstrap_disabled",
+        testopt_bootstrap = "False",
     ),
     manifest = None,
 )

--- a/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/chip_specific_startup/BUILD
@@ -30,7 +30,6 @@ package(default_visibility = ["//visibility:public"])
             otp = "//sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry:otp_img_e2e_bootstrap_entry_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
             test_cmd = """
-                --bootstrap="{firmware}"
                 --otp-unprogrammed
             """,
             test_harness = "//sw/host/tests/rom/e2e_chip_specific_startup",

--- a/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/jtag_inject/BUILD
@@ -55,6 +55,7 @@ package(default_visibility = ["//visibility:public"])
                 --elf={sram_program}
             """,
             test_harness = "//sw/host/tests/chip/jtag:sram_load",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -96,6 +97,7 @@ test_suite(
             otp = ":img_{}_exec_disabled".format(lc_state),
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:asm_interrupt_handler",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -137,6 +139,7 @@ test_suite(
             otp = ":img_{}_exec_disabled".format(lc_state),
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:shutdown_execution_asm",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -179,6 +182,7 @@ test_suite(
             tags = ["broken"],
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:asm_watchdog_bark",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -221,6 +225,7 @@ test_suite(
             tags = ["broken"],
             test_cmd = " --elf={rom:elf}",
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:asm_watchdog_bite",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",
@@ -269,6 +274,7 @@ LC_STATES_DEBUG_DISALLOWED = [
             otp = ":img_{}_exec_disabled".format(lc_state),
             test_cmd = " --elf={rom:elf}" + (" --expect-fail" if lc_state_val in LC_STATES_DEBUG_DISALLOWED else " "),
             test_harness = "//sw/host/tests/rom/e2e_openocd_debug_test:debug_test",
+            testopt_bootstrap = "False",
         ),
         deps = [
             "//sw/device/lib/runtime:log",

--- a/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/reset_reason/BUILD
@@ -67,14 +67,14 @@ RESET_CORRUPTION_SCENARIOS = [
         "otp": 0,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_disabled_no_fault",
         "otp": CONST.HARDENED_FALSE << 16 | CONST.HARDENED_FALSE,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_disabled_with_fault",
@@ -84,14 +84,14 @@ RESET_CORRUPTION_SCENARIOS = [
         "otp": CONST.HARDENED_FALSE << 16 | 0,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_enabled_no_fault",
         "otp": CONST.HARDENED_TRUE << 16 | CONST.HARDENED_TRUE,
         "exit_success": DEFAULT_TEST_SUCCESS_MSG,
         "exit_failure": DEFAULT_TEST_FAILURE_MSG,
-        "test_cmd": "",
+        "testopt_bootstrap": "True",
     },
     {
         "name": "check_enabled_with_fault",
@@ -104,12 +104,7 @@ RESET_CORRUPTION_SCENARIOS = [
         "exit_failure": DEFAULT_TEST_SUCCESS_MSG,
         # This test will fault before bootstrap straps are read, so simply
         # start the console and look for the fault message.
-        "test_cmd": """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        "testopt_bootstrap": "False",
     },
 ]
 
@@ -150,7 +145,7 @@ RESET_CORRUPTION_SCENARIOS = [
             exit_failure = t["exit_failure"],
             exit_success = t["exit_success"],
             otp = ":otp_img_reset_reason_{}".format(t["name"]),
-            test_cmd = t["test_cmd"],
+            testopt_bootstrap = t["testopt_bootstrap"],
         ),
         deps = [
             "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_e2e_bootstrap_entry/BUILD
@@ -44,9 +44,6 @@ package(default_visibility = ["//visibility:public"])
             binaries = {"//sw/device/silicon_creator/rom/e2e:new_empty_test_slot_a": "firmware"},
             otp = ":otp_img_e2e_bootstrap_entry_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
-            test_cmd = """
-                --bootstrap="{firmware}"
-            """,
             test_harness = "//sw/host/tests/rom/e2e_bootstrap_entry",
         ),
         # We don't want the `empty_test` to run, but we _also_ don't want some

--- a/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
+++ b/sw/device/silicon_creator/rom/e2e/rom_ext_upgrade_interrupt/BUILD
@@ -72,15 +72,8 @@ otp_json(
         fpga = fpga_params(
             otp = ":otp_img_rom_ext_upgrade_interrupt_{}".format(lc_state),
             tags = maybe_skip_in_ci(lc_state_val),
-            test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-                --exec="fpga clear-bitstream"
-                no-op
-            """,
+            testopt_clear_after_test = "True",
+            testopt_clear_before_test = "True",
         ),
         manifest = ":manifest_rom_ext_upgrade_interrupt",
         deps = [

--- a/sw/device/silicon_creator/rom/instrumented_header.c
+++ b/sw/device/silicon_creator/rom/instrumented_header.c
@@ -1,0 +1,11 @@
+#include "sw/device/lib/base/macros.h"
+
+/* Instrumented ROM magic value.
+ *
+ * This value is placed at the very beginning of the instrumented ROM image
+ * after vector table. This can be used to check the existence of an
+ * instrumented ROM on the Flash.
+ */
+OT_USED
+OT_SECTION(".instrumented_rom_magic")
+char instrumented_rom_magic[4] = "IROM";

--- a/sw/device/silicon_creator/rom/rom_common.ld
+++ b/sw/device/silicon_creator/rom/rom_common.ld
@@ -77,6 +77,17 @@ SECTIONS {
   } > rom_region
 
   /**
+   * Magic bytes to indicate the instrumented ROM's existence on Flash.
+   */
+  .instrumented_rom_magic : ALIGN(4) {
+    KEEP(*(.instrumented_rom_magic))
+
+    ASSERT(
+      DEFINED(_ot_coverage_enabled) || SIZEOF(.instrumented_rom_magic) == 0,
+      ".instrumented_rom_magic section must be empty when coverage is disabled.");
+  } > rom_region
+
+  /**
    * C runtime (CRT) section, containing program initialization code.
    *
    * This is a separate section to `.text` so that the jumps inside `.vectors`

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -370,6 +370,7 @@ manifest(d = {
         exec_env = [
             "//hw/top_earlgrey:fpga_cw340",
             "//hw/top_earlgrey:fpga_cw310",
+            "//hw/top_earlgrey:sim_qemu_base",
         ],
         extra_bazel_features = [
             "minsize",

--- a/sw/device/silicon_creator/rom_ext/e2e/attestation/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/attestation/BUILD
@@ -7,6 +7,7 @@ load(
     "fpga_params",
     "opentitan_binary",
     "opentitan_test",
+    "qemu_params",
 )
 
 package(default_visibility = ["//visibility:public"])
@@ -20,6 +21,7 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     deps = [
@@ -37,8 +39,18 @@ opentitan_test(
     exec_env = {
         "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     fpga = fpga_params(
+        binaries = {
+            ":print_certs": "firmware",
+        },
+        test_cmd = """
+            --bootstrap={firmware}
+        """,
+        test_harness = "//sw/host/tests/attestation:attestation_test",
+    ),
+    qemu = qemu_params(
         binaries = {
             ":print_certs": "firmware",
         },

--- a/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/boot_svc/BUILD
@@ -81,9 +81,6 @@ opentitan_test(
         exit_failure = "BFV|PASS|FAIL",
         exit_success = "mode: RESQ\r\n",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             # Try the `REBO` mode and make sure it works.
             --exec="rescue no-op --reset-target=reboot"
@@ -166,9 +163,9 @@ NEXT_TEST_SEQUENCES = [
         },
         fpga = fpga_params(
             assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a} {firmware}@{owner_slot_b}",
-            changes_otp = True,  # Clear the primary slot settings
             exit_failure = "BFV:.*|PASS|FAIL",
             exit_success = "FinalBootLog: 3:{}\r\n".format(test_sequence),
+            testopt_clear_after_test = "True",  # Clear the primary slot settings
         ),
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         qemu = qemu_params(
@@ -204,14 +201,7 @@ opentitan_test(
         assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_a} {firmware}@{owner_slot_b}",
         exit_failure = "BFV:.*|PASS|FAIL",
         exit_success = "FinalBootLog: 5:ABBBA\r\n",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        testopt_clear_before_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     qemu = qemu_params(
@@ -358,15 +348,8 @@ MIN_SEC_VER_SLOTS = [
             binaries = {
                 ":min_sec_ver_5": "min_sec_ver_5",
             },
-            test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-                --exec="fpga clear-bitstream"
-                no-op
-            """,
+            testopt_clear_after_test = "True",
+            testopt_clear_before_test = "True",
             v0_slot = "{{owner_slot_{}}}".format(slots[0]),
             v5_slot = "{{owner_slot_{}}}".format(slots[1]),
         ),

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -128,11 +128,10 @@ _VARIATION_INTEROP_TEST_CASES = [
             },
             otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
             test_cmd = """
-                --clear-bitstream
-                --bootstrap={firmware}
                 --second-bootstrap={second}
             """,
             test_harness = "//sw/host/tests/rom_ext/e2e_variation_interop",
+            testopt_clear_before_test = "True",
         ),
         qemu = qemu_params(
             binaries = {
@@ -207,11 +206,9 @@ opentitan_test(
         binaries = {
             ":modify_digest": "modify_digest",
         },
-        test_cmd = ("""
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-        """ + CORRUPTED_DIGEST_TEST_CMDS),
+        test_cmd = CORRUPTED_DIGEST_TEST_CMDS,
+        testopt_bootstrap = "False",
+        testopt_clear_before_test = "True",
     ),
     qemu = qemu_params(
         binaries = {

--- a/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/dice_chain/BUILD
@@ -10,6 +10,7 @@ load(
     "fpga_params",
     "opentitan_binary",
     "opentitan_test",
+    "qemu_params",
 )
 load(
     "//sw/device/silicon_creator/rom/e2e:defs.bzl",
@@ -33,8 +34,14 @@ package(default_visibility = ["//visibility:public"])
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
             "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+            "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
         fpga = fpga_params(
+            exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
+            exit_success = "Rebooted\r\n",
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+        ),
+        qemu = qemu_params(
             exit_failure = "Rebooting[\\s\\S]*CDI_1 certificate not valid[\\s\\S]*Rebooted",
             exit_success = "Rebooted\r\n",
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
@@ -64,6 +71,7 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_a",
     manifest = ":owner_manifest",
@@ -87,7 +95,8 @@ opentitan_binary(
         },
         exec_env = [
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys",
-            # "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+            "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+            "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys",
         ],
     )
     for variation in ROM_EXT_VARIATIONS.keys()
@@ -110,6 +119,7 @@ _VARIATION_INTEROP_TEST_CASES = [
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_with_fake_keys": None,
             "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys": None,
+            "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys": None,
         },
         fpga = fpga_params(
             binaries = {
@@ -119,6 +129,18 @@ _VARIATION_INTEROP_TEST_CASES = [
             otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
             test_cmd = """
                 --clear-bitstream
+                --bootstrap={firmware}
+                --second-bootstrap={second}
+            """,
+            test_harness = "//sw/host/tests/rom_ext/e2e_variation_interop",
+        ),
+        qemu = qemu_params(
+            binaries = {
+                ":dice_{}_rom_ext_owner_bundle".format(tc["second"]): "second",
+                ":dice_{}_rom_ext_owner_bundle".format(tc["first"]): "firmware",
+            },
+            otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_rma",
+            test_cmd = """
                 --bootstrap={firmware}
                 --second-bootstrap={second}
             """,
@@ -145,6 +167,7 @@ opentitan_binary(
     srcs = ["modify_digest.c"],
     exec_env = [
         "//hw/top_earlgrey:fpga_cw340_rom_with_fake_keys",
+        "//hw/top_earlgrey:sim_qemu_rom_with_fake_keys",
     ],
     deps = [
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
@@ -158,33 +181,45 @@ opentitan_binary(
     ],
 )
 
+CORRUPTED_DIGEST_TEST_CMDS = """
+    --exec="no-op --info='##### Prepare CDI cert page'"
+    --exec="bootstrap --clear-uart=true {firmware}"
+    --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
+    --exec="no-op --info='##### Corrupt CDI cert page'"
+    --exec="bootstrap --clear-uart=true {modify_digest}"
+    --exec="console --non-interactive --exit-success='PASS!' --timeout=10s"
+    --exec="bootstrap --clear-uart=true {firmware}"
+    --exec="no-op --info='##### Corruption should be detected and reboot'"
+    --exec="console --non-interactive --exit-success='BFV:03444303' --exit-failure='{exit_success}' --timeout=10s"
+    --exec="no-op --info='##### Corruption fixed in the second boot'"
+    --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
+    no-op
+"""
+
 opentitan_test(
     name = "corrupted_digest_test",
     srcs = ["//sw/device/silicon_creator/rom_ext/e2e/verified_boot:boot_test"],
     exec_env = {
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     fpga = fpga_params(
         binaries = {
             ":modify_digest": "modify_digest",
         },
-        test_cmd = """
+        test_cmd = ("""
             --exec="transport init"
             --exec="fpga clear-bitstream"
             --exec="fpga load-bitstream {bitstream}"
-            --exec="no-op --info='##### Prepare CDI cert page'"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
-            --exec="no-op --info='##### Corrupt CDI cert page'"
-            --exec="bootstrap --clear-uart=true {modify_digest}"
-            --exec="console --non-interactive --exit-success='PASS!' --timeout=10s"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="no-op --info='##### Corruption should be detected and reboot'"
-            --exec="console --non-interactive --exit-success='BFV:03444303' --exit-failure='{exit_success}' --timeout=10s"
-            --exec="no-op --info='##### Corruption fixed in the second boot'"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
-            no-op
-        """,
+        """ + CORRUPTED_DIGEST_TEST_CMDS),
+    ),
+    qemu = qemu_params(
+        binaries = {
+            ":modify_digest": "modify_digest",
+        },
+        test_cmd = ("""
+            --exec="transport init"
+        """ + CORRUPTED_DIGEST_TEST_CMDS),
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -219,8 +254,12 @@ DEBUG_MODE_TESTCASES = [
         exec_env = {
             "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
             "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+            "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
         fpga = fpga_params(
+            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
+        ),
+        qemu = qemu_params(
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_{}_slot_a".format(variation),
         ),
         deps = [

--- a/sw/device/silicon_creator/rom_ext/e2e/flash_ecc_error/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/flash_ecc_error/BUILD
@@ -183,8 +183,6 @@ opentitan_binary(
             primary = t["primary"],
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
                 # First run the setup program to make sure the keymgr secrets are configured.
                 # This is required to allow the ROM_EXT to run.
                 --exec="bootstrap --clear-uart=true {setup}"
@@ -199,6 +197,7 @@ opentitan_binary(
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_bootstrap = "False",
         ),
     )
     for t in BOOT_POLICY_FLASH_ECC_ERROR_TESTS
@@ -227,8 +226,6 @@ opentitan_test(
         primary = "SlotA",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
             # First run the setup program to make sure the keymgr secrets are configured.
             # This is required to allow the ROM_EXT to run.
             --exec="bootstrap --clear-uart=true {setup}"
@@ -243,6 +240,7 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_bootstrap = "False",
     ),
 )
 

--- a/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/handoff/BUILD
@@ -170,14 +170,7 @@ SRAM_EXEC_TESTCASES = [
             changes_otp = True,
             exit_success = test["exit_success"],
             rom_ext = test["rom_ext"],
-            test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
-                --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-                no-op
-            """,
+            testopt_clear_before_test = "True",
         ),
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         deps = [
@@ -206,7 +199,6 @@ opentitan_test(
         rom_ext_sec_version = ROM_EXT_VERSION.SECURITY,
         rom_ext_version = ROM_EXT_VERSION.MINOR,
         test_cmd = """
-            --bootstrap={firmware}
             --wait-for="PASS!"
             --rom-ext-version="{rom_ext_version}"
             --rom-ext-sec-version="{rom_ext_sec_version}"

--- a/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/isfb/BUILD
@@ -76,10 +76,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
         # Check that bank=0 page=5 is configured for RD/WR, but not ERase.
         exit_success = "info region bank=0 part=0 page=5 RD-WR-uu-uu-uu-uu LK",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb",
+        testopt_clear_after_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
@@ -101,13 +101,13 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
         # Even though the isfb_erase extension is present and set to true,
         # the manifest doesn't node lock this image.  The erase condition
         # is not met and the ISFB page should not allow erase.
         # Check that bank=0 page=5 is configured for RD/WR, but not ERase.
         exit_success = "info region bank=0 part=0 page=5 RD-WR-uu-uu-uu-uu LK",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb",
+        testopt_clear_after_test = "True",
     ),
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     manifest = ":manifest_bad_erase_contraint",
@@ -224,21 +224,20 @@ _ISFB_CONTRAINT_TESTS = {
             binaries = {
                 ":isfb_page_init": "isfb_page_init",
             },
-            changes_otp = True,
             exit_failure = param["failure"],
             exit_success = param["success"],
             rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_isfb",
             test_cmd = """
                 --exec="image assemble --output=init.bin --mirror=false --size=524288 {rom_ext}@{rom_ext_slot_a} {isfb_page_init}@{owner_slot_a}"
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true init.bin"
                 --exec="console --non-interactive --exit-success='PASS!' --timeout=10s"
                 --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}' --timeout=10s"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",
+            testopt_clear_before_test = "True",
         ),
         linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
         manifest = param["manifest"],

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -6,6 +6,7 @@ load(
     "//rules/opentitan:defs.bzl",
     "fpga_params",
     "opentitan_binary",
+    "qemu_params",
 )
 load(
     "//sw/device/silicon_creator/rom_ext/e2e/ownership:defs.bzl",
@@ -21,6 +22,17 @@ package(default_visibility = ["//visibility:public"])
 # so we need to clear the bitstream after the test, which is what the
 # `changes_otp` parameter actually does.
 
+# When running the ownership tests in QEMU, be careful not to run with a high
+# degree of parallelism or on a slower host. This is because the XModem-CRC
+# rescue implementation defines a timeout to receive the Xmodem frame data (300
+# ms) based upon a UART transferring at ~115200bps, with ~3x lenience (see
+# `sw/device/silicon_creator/lib/rescue/xmodem.c`). When running in QEMU, the
+# baud rate is not used and data will transfer via a PTY-backed CharDev at a
+# speed that depends on host performance and load.
+#
+# To reliably run the Xmodem rescue flow for ownership transfer, it is
+# recommended to sequence test runs serially.
+
 opentitan_binary(
     name = "boot_test",
     testonly = True,
@@ -32,6 +44,7 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     deps = [
         "//sw/device/lib/base:status",
@@ -53,6 +66,7 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
     deps = [
@@ -84,10 +98,9 @@ manifest({
 ownership_transfer_test(
     name = "transfer_any_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0"},
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -96,8 +109,8 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -111,10 +124,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -124,8 +136,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --activate-bl0-slot=SlotB
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -139,11 +151,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -154,8 +165,8 @@ ownership_transfer_test(
             --invalid-device-id=true
             --expected-error=OwnershipInvalidDin
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -169,11 +180,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -184,8 +194,8 @@ ownership_transfer_test(
             --invalid-nonce=true
             --expected-error=OwnershipInvalidNonce
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -199,11 +209,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_invalid_key_alg",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_invalid_key_alg",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -214,8 +223,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --dual-owner-boot-check=false
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -229,13 +238,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -247,8 +255,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -259,10 +267,9 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "bad_unlock_signature_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -273,8 +280,8 @@ ownership_transfer_test(
             --unlock-sig=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:all_zero_sig)
             --expected-error=OwnershipSignatureNotFound
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -282,14 +289,13 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
-        test_cmd = """
-            --clear-bitstream
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -299,8 +305,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --expected-error=OwnershipInvalidAlgorithm
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -314,14 +320,13 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
-        test_cmd = """
-            --clear-bitstream
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
@@ -334,8 +339,8 @@ ownership_transfer_test(
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
             --expected-error=OwnershipInvalidAlgorithm
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -346,10 +351,9 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "bad_appkey_constraint_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -360,16 +364,16 @@ ownership_transfer_test(
             --config-kind=with-app-constraint
             --expected-error=SigverifyBadEcdsaSignature
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "good_appkey_constraint_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    manifest = ":nodelocked_manifest",
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -379,18 +383,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --config-kind=with-app-constraint
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
-    manifest = ":nodelocked_manifest",
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_unlock_test
 ownership_transfer_test(
     name = "bad_unlock_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the wrong unlock key to test that the unlock operation fails.
@@ -401,17 +403,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipInvalidSignature
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "unlock_when_recovery_state_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_recovery",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_recovery",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
@@ -421,16 +422,15 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
     name = "unlock_with_owner_recovery_key_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
@@ -440,17 +440,16 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:app_prod_ecdsa_pub)
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_activate_test
 ownership_transfer_test(
     name = "bad_activate_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -462,17 +461,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipInvalidSignature
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_owner_block_test
 ownership_transfer_test(
     name = "bad_owner_block_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -484,17 +482,16 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_app_key_test
 ownership_transfer_test(
     name = "bad_app_key_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -506,17 +503,16 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/fake/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipKeyNotFound
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_endorsed_test
 ownership_transfer_test(
     name = "transfer_endorsed_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -526,17 +522,16 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_endorsee_test
 ownership_transfer_test(
     name = "bad_endorsee_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -549,17 +544,16 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_locked_update_test
 ownership_transfer_test(
     name = "locked_update_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -571,8 +565,8 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --non-transfer-update=true
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
@@ -582,10 +576,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -597,18 +590,17 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipInvalidInfoPage
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_locked_update_test
 # Part 2: Ensure the UnlockedSelf state denies execution to anything signed with new app keys.
 ownership_transfer_test(
     name = "bad_locked_update_no_exec_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -622,21 +614,21 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --expected-error=OwnershipKeyNotFound
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_limit_test
 ownership_transfer_test(
     name = "rescue_limit_test",
     srcs = ["flash_contents.c"],
-    fpga = fpga_params(
-        timeout = "long",
+    fpga = {"changes_otp": True},
+    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+    shared_params = {
+        "timeout": "long",
         # We boot on Side B since rescue will rewrite side A.
-        assemble = "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -645,9 +637,8 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:rescue_limit_test",
-    ),
-    linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
+        "test_harness": "//sw/host/tests/ownership:rescue_limit_test",
+    },
     deps = [
         "//hw/top_earlgrey/ip_autogen/flash_ctrl:flash_ctrl_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -661,10 +652,9 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_permission_test
 ownership_transfer_test(
     name = "rescue_permission_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -673,8 +663,8 @@ ownership_transfer_test(
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:activate_key)
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
         """,
-        test_harness = "//sw/host/tests/ownership:rescue_permission_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:rescue_permission_test",
+    },
 )
 
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_flash_permission_test
@@ -707,18 +697,17 @@ _FLASH_PERMISSION_TESTS = {
     ownership_transfer_test(
         name = "flash_permission_test_slot_{}".format(name),
         srcs = ["flash_regions.c"],
-        fpga = fpga_params(
-            assemble = "{rom_ext}@{rom_ext_offset} {firmware}@{owner_slot_a}",
-            binaries = {
+        fpga = {"changes_otp": True},
+        shared_params = {
+            "assemble": "{rom_ext}@{rom_ext_offset} {firmware}@{owner_slot_a}",
+            "binaries": {
                 ":flash_regions": "flash_regions",
             },
-            changes_otp = True,
-            owner_slot = param["owner_slot"],
-            rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
-            rom_ext_offset = param["rom_ext_offset"],
-            rom_ext_slot = param["rom_ext_slot"],
-            test_cmd = """
-                --clear-bitstream
+            "owner_slot": param["owner_slot"],
+            "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_virtual",
+            "rom_ext_offset": param["rom_ext_offset"],
+            "rom_ext_slot": param["rom_ext_slot"],
+            "test_cmd": """
                 --bootstrap={firmware}
                 --unlock-mode=Any
                 --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -731,9 +720,8 @@ _FLASH_PERMISSION_TESTS = {
                 --rescue-slot={owner_slot}
                 --expected-rom-ext-slot={rom_ext_slot}
             """,
-            test_harness = "//sw/host/tests/ownership:flash_permission_test",
-        ),
-        linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_virtual",
+            "test_harness": "//sw/host/tests/ownership:flash_permission_test",
+        },
         deps = [
             "//hw/top_earlgrey/sw/autogen:top_earlgrey",
             "//sw/device/lib/base:status",
@@ -750,10 +738,9 @@ _FLASH_PERMISSION_TESTS = {
 # Tests that a owner config with an improper flash configuration cannot be activated.
 ownership_transfer_test(
     name = "flash_error_test",
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -765,8 +752,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --expected-error=OwnershipFlashConfigRomExt
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 # Test that the `sku_creator_owner_init` function responsible for installing the test owner on
@@ -776,10 +763,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -793,8 +779,8 @@ ownership_transfer_test(
             --next-application-key=sw/device/silicon_creator/lib/ownership/keys/dummy/app_prod_ecdsa_p256.pub.der
             --non-transfer-update=true
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
 )
 
 ownership_transfer_test(
@@ -802,11 +788,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -817,8 +802,8 @@ ownership_transfer_test(
             --expect "config_version = 2"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -826,11 +811,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -842,8 +826,8 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -851,11 +835,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -866,8 +849,8 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -875,11 +858,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -891,8 +873,8 @@ ownership_transfer_test(
             --expect "config_version = 2"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -900,11 +882,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -916,8 +897,8 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 opentitan_binary(
@@ -934,6 +915,7 @@ opentitan_binary(
     exec_env = {
         "//hw/top_earlgrey:fpga_cw310_rom_ext": None,
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+        "//hw/top_earlgrey:sim_qemu_rom_ext": None,
     },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -958,13 +940,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":keymgr_test": "keymgr_test",
         },
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "test_cmd": """
             --bootstrap={firmware}
             --pre-transfer-boot-check=true
             --unlock-mode=Any
@@ -976,8 +957,8 @@ ownership_transfer_test(
             --rescue-after-activate={keymgr_test}
             --keygen-check=true
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:status",
@@ -993,13 +974,12 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_ecdsa_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        test_cmd = """
-            --clear-bitstream
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -1014,8 +994,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -1027,14 +1007,13 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_pq_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
-        test_cmd = """
-            --clear-bitstream
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
@@ -1048,8 +1027,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -1063,14 +1042,13 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        binaries = {
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "binaries": {
             ":boot_test": "boot_test",
         },
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spx_pure_owner_keys",
-        test_cmd = """
-            --clear-bitstream
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_spx_pure_owner_keys",
+        "test_cmd": """
             --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=SpxPure
@@ -1083,8 +1061,8 @@ ownership_transfer_test(
             --dual-owner-boot-check=false
             --rescue-after-activate={boot_test}
         """,
-        test_harness = "//sw/host/tests/ownership:transfer_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:transfer_test",
+    },
     deps = [
         "//sw/device/lib/base:status",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -1098,11 +1076,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -1117,8 +1094,8 @@ ownership_transfer_test(
             --expect "config_version = 2"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )
 
 ownership_transfer_test(
@@ -1126,11 +1103,10 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = fpga_params(
-        changes_otp = True,
-        rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
-        test_cmd = """
-            --clear-bitstream
+    fpga = {"changes_otp": True},
+    shared_params = {
+        "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
+        "test_cmd": """
             --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -1142,6 +1118,6 @@ ownership_transfer_test(
             --expect "config_version = 1"
             --expect "owner_key = 8e3dcb50"
         """,
-        test_harness = "//sw/host/tests/ownership:newversion_test",
-    ),
+        "test_harness": "//sw/host/tests/ownership:newversion_test",
+    },
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/BUILD
@@ -17,11 +17,6 @@ load("//rules:manifest.bzl", "manifest")
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO(#24462): The tests in this file are marked `changes_otp = True`,
-# but they don't change OTP.  They modify the ownership INFO pages,
-# so we need to clear the bitstream after the test, which is what the
-# `changes_otp` parameter actually does.
-
 # When running the ownership tests in QEMU, be careful not to run with a high
 # degree of parallelism or on a slower host. This is because the XModem-CRC
 # rescue implementation defines a timeout to receive the Xmodem frame data (300
@@ -98,10 +93,8 @@ manifest({
 ownership_transfer_test(
     name = "transfer_any_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0"},
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -124,10 +117,8 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -151,11 +142,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -180,11 +169,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_unlock_any",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Abort
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -209,11 +196,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_invalid_key_alg",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --skip-unlock=true
@@ -238,13 +223,11 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",
         },
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -267,10 +250,8 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "bad_unlock_signature_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -289,14 +270,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",
         },
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -320,14 +299,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",
         },
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_corrupted_owner_key_alg",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -351,10 +328,8 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "bad_appkey_constraint_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -370,11 +345,9 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "good_appkey_constraint_test",
-    fpga = {"changes_otp": True},
     manifest = ":nodelocked_manifest",
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -390,10 +363,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_unlock_test
 ownership_transfer_test(
     name = "bad_unlock_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the wrong unlock key to test that the unlock operation fails.
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -409,11 +380,9 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "unlock_when_recovery_state_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_default_ownership_state_recovery",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)
@@ -428,10 +397,8 @@ ownership_transfer_test(
 
 ownership_transfer_test(
     name = "unlock_with_owner_recovery_key_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             # NOTE: We use the owner recovery key to test that the unlock operation succeeds.
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:no_owner_recovery_key)
@@ -447,10 +414,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_activate_test
 ownership_transfer_test(
     name = "bad_activate_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             # NOTE: We use the wrong activate key to test that the activate operation fails.
@@ -468,10 +433,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_owner_block_test
 ownership_transfer_test(
     name = "bad_owner_block_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -489,10 +452,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_app_key_test
 ownership_transfer_test(
     name = "bad_app_key_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -510,10 +471,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_transfer_endorsed_test
 ownership_transfer_test(
     name = "transfer_endorsed_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -529,10 +488,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_bad_endorsee_test
 ownership_transfer_test(
     name = "bad_endorsee_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Endorsed
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -551,10 +508,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_locked_update_test
 ownership_transfer_test(
     name = "locked_update_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
@@ -576,10 +531,8 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             # NOTE: We use the wrong owner key to test that the activate operation fails.
@@ -598,10 +551,8 @@ ownership_transfer_test(
 # Part 2: Ensure the UnlockedSelf state denies execution to anything signed with new app keys.
 ownership_transfer_test(
     name = "bad_locked_update_no_exec_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -622,14 +573,12 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "rescue_limit_test",
     srcs = ["flash_contents.c"],
-    fpga = {"changes_otp": True},
     linker_script = "//sw/device/lib/testing/test_framework:ottf_ld_silicon_owner_slot_b",
     shared_params = {
         "timeout": "long",
         # We boot on Side B since rescue will rewrite side A.
         "assemble": "{rom_ext}@{rom_ext_slot_a} {firmware}@{owner_slot_b}",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -652,10 +601,8 @@ ownership_transfer_test(
 # rom_ext_e2e_testplan.hjson%rom_ext_e2e_rescue_permission_test
 ownership_transfer_test(
     name = "rescue_permission_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -697,7 +644,6 @@ _FLASH_PERMISSION_TESTS = {
     ownership_transfer_test(
         name = "flash_permission_test_slot_{}".format(name),
         srcs = ["flash_regions.c"],
-        fpga = {"changes_otp": True},
         shared_params = {
             "assemble": "{rom_ext}@{rom_ext_offset} {firmware}@{owner_slot_a}",
             "binaries": {
@@ -708,7 +654,6 @@ _FLASH_PERMISSION_TESTS = {
             "rom_ext_offset": param["rom_ext_offset"],
             "rom_ext_slot": param["rom_ext_slot"],
             "test_cmd": """
-                --bootstrap={firmware}
                 --unlock-mode=Any
                 --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
                 --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -738,10 +683,8 @@ _FLASH_PERMISSION_TESTS = {
 # Tests that a owner config with an improper flash configuration cannot be activated.
 ownership_transfer_test(
     name = "flash_error_test",
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/dummy:owner_key)
@@ -763,10 +706,8 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Update
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
@@ -788,11 +729,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -811,11 +750,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -835,11 +772,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -858,11 +793,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -882,11 +815,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -940,13 +871,11 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":keymgr_test": "keymgr_test",
         },
         "test_cmd": """
-            --bootstrap={firmware}
             --pre-transfer-boot-check=true
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -974,13 +903,11 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_ecdsa_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",
         },
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-key-alg=HybridSpxPure
@@ -1007,14 +934,12 @@ ownership_transfer_test(
 ownership_transfer_test(
     name = "transfer_pq_to_pq_test",
     ecdsa_key = {"//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0"},
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",
         },
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_keys",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=HybridSpxPure
             --unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
@@ -1042,14 +967,12 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "binaries": {
             ":boot_test": "boot_test",
         },
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_spx_pure_owner_keys",
         "test_cmd": """
-            --bootstrap={firmware}
             --unlock-mode=Any
             --key-alg=SpxPure
             --unlock-key-spx=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key_spx)
@@ -1076,11 +999,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)
@@ -1103,11 +1024,9 @@ ownership_transfer_test(
     ecdsa_key = {
         "//sw/device/silicon_creator/lib/ownership/keys/fake:ecdsa_keyset": "app_prod_0",
     },
-    fpga = {"changes_otp": True},
     shared_params = {
         "rom_ext": "//sw/device/silicon_creator/rom_ext:rom_ext_hybrid_owner_update_newversion",
         "test_cmd": """
-            --bootstrap={firmware}
             --next-owner-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:owner_key)
             --next-unlock-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:unlock_key)
             --next-activate-key=$(location //sw/device/silicon_creator/lib/ownership/keys/fake:activate_key)

--- a/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
+++ b/sw/device/silicon_creator/rom_ext/e2e/ownership/defs.bzl
@@ -4,8 +4,11 @@
 
 load(
     "//rules/opentitan:defs.bzl",
+    "fpga_params",
     "opentitan_test",
+    "qemu_params",
 )
+load("@bazel_skylib//lib:structs.bzl", "structs")
 
 def ownership_transfer_test(
         name,
@@ -13,6 +16,7 @@ def ownership_transfer_test(
         exec_env = {
             "//hw/top_earlgrey:fpga_hyper310_rom_ext": None,
             "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
+            "//hw/top_earlgrey:sim_qemu_rom_ext": None,
         },
         ecdsa_key = {
             "//sw/device/silicon_creator/lib/ownership/keys/dummy:ecdsa_keyset": "app_prod_0",
@@ -49,7 +53,55 @@ def ownership_transfer_test(
             "//sw/device/silicon_creator/lib/drivers:retention_sram",
             "//sw/device/silicon_creator/lib/ownership:datatypes",
         ],
+        fpga = None,
+        qemu = None,
+        shared_params = None,
         **kwargs):
+    # Construct `fpga_params` from shared and FPGA-specific parameters
+    if shared_params:
+        override_params = dict(shared_params)
+        if fpga:
+            override_params.update(fpga)
+
+        # FPGA should always clear the bitstream & bootstrap first, so
+        # add these to every FPGA test cmd unless overridden
+        if not fpga or "test_cmd" not in fpga:
+            override_params["test_cmd"] = """
+                --clear-bitstream
+            """ + override_params["test_cmd"]
+        fpga = fpga_params(**override_params)
+    else:
+        fpga = fpga_params(**fpga)
+
+    # Construct `qemu_params` from shared and QEMU-specific parameters
+    if shared_params:
+        override_params = dict(shared_params)
+        if qemu:
+            override_params.update(qemu)
+
+        # QEMU takes longer to emulate entering rescue due to slow
+        # emulation of the ROM, as a result of the `sec_mmio` code hot
+        # loops falling in a misaligned EPMP region that effectively
+        # disables QEMU's TCG TLB optimisations. As such, we always
+        # increase the delay to enter rescue to 20s on QEMU targets.
+        # This is likely much larger than needed, but should give some
+        # lenience for tests being run in parallel or on slower hosts.
+        if not qemu or "test_cmd" not in qemu:
+            override_params["test_cmd"] = """
+                --rescue-enter-delay=20s
+            """ + override_params["test_cmd"]
+
+        # XModem-CRC transfer as part of the rescue flow uses somewhat
+        # tight timing based on the UART baud rate, which depends on
+        # the performance & load of the host. Change the icount shift
+        # used to make timing more lenient on QEMU, albeit at the cost
+        # of longer test executions.
+        if not qemu or "icount" not in qemu:
+            override_params["icount"] = "5"
+        qemu = qemu_params(**override_params)
+    else:
+        qemu = qemu_params(**qemu)
+
     opentitan_test(
         name = name,
         srcs = srcs,
@@ -59,5 +111,7 @@ def ownership_transfer_test(
         data = data,
         defines = defines,
         deps = deps,
+        fpga = fpga,
+        qemu = qemu,
         **kwargs
     )

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -221,6 +221,7 @@ genrule(
                 --exec="fpga clear-bitstream"
                 --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {firmware}"
+                --exec="console --non-interactive --timeout=100ms"
                 {setup}
                 --exec="no-op --info='##### Set next slot via the rescue protocol'"
                 --exec="rescue {params} boot-svc set-next-bl0-slot --next=SlotB --get-response=false"

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -115,16 +115,12 @@ _CONFIGS = {
             binaries = {
                 ":boot_test_{}".format(name): "payload",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
             slot = position["slot"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
                 {setup}
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
@@ -135,6 +131,9 @@ _CONFIGS = {
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for name, position in _POSITIONS.items()
@@ -176,7 +175,6 @@ genrule(
                 ":boot_test_{}".format(name): "payload",
                 ":bad_rom_ext": "bad_rom_ext",
             },
-            changes_otp = True,  # See important note at the top
             exit_failure = _RESCUE_ROMEXT_RESULTS[name == rxslot]["failure"],
             exit_success = _RESCUE_ROMEXT_RESULTS[name == rxslot]["success"].format(slot = name),
             image_name = "rescue_rom_ext_{}.img".format(name),
@@ -184,9 +182,6 @@ genrule(
             rom_ext_offset = _POSITIONS[rxslot]["rom_ext_offset"],
             slot = position["slot"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
                 --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
                 # Construct a firmware image with the bad ROM_EXT
@@ -197,6 +192,7 @@ genrule(
                 --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_clear_after_test = "True",  # See important note at the top
         ),
     )
     for name, position in _POSITIONS.items()
@@ -216,16 +212,11 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
                 --exec="console --non-interactive --timeout=100ms"
                 {setup}
                 --exec="no-op --info='##### Set next slot via the rescue protocol'"
@@ -238,6 +229,8 @@ genrule(
                 --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -256,16 +249,12 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
-                --exec="bootstrap --clear-uart=true {firmware}"
+                --exec="console --non-interactive --timeout=100ms"
                 {setup}
                 --exec="no-op --info='##### Set primary slot via the rescue protocol'"
                 --exec="rescue {params} boot-svc set-next-bl0-slot --primary=SlotB --get-response=false"
@@ -281,6 +270,8 @@ genrule(
                 --exec="console --non-interactive --exit-success='bl0_slot = AA__\r\n' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -298,11 +289,8 @@ genrule(
             binaries = {
                 ":boot_test_slot_a": "payload",
             },
-            changes_otp = True,  # See important note at the top
             rate = rate,
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # First make sure the ROM_EXT is faulting because there is no firmware
                 --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
@@ -312,6 +300,8 @@ genrule(
                 --exec="console --baudrate=115200 --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
         ),
     )
     # FPGA CW310 and CW340 only support the baudrate up to 230K.
@@ -333,11 +323,8 @@ genrule(
             binaries = {
                 ":boot_test_slot_a": "payload",
             },
-            changes_otp = True,  # See important note at the top
             rate = rate,
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga load-bitstream {bitstream}"
                 --exec="bootstrap --clear-uart=true {rom_ext}"
                 # Trigger rescue.
                 --exec="rescue no-op"
@@ -346,6 +333,8 @@ genrule(
                 --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
         ),
     )
     # FPGA CW310 and CW340 only support the baudrate up to 230K.
@@ -374,11 +363,8 @@ opentitan_test(
         binaries = {
             ":boot_test_slot_a": "payload",
         },
-        changes_otp = True,  # See important note at the top
         rom_ext = "//sw/device/silicon_creator/rom_ext/e2e/rescue/testdata:rom_ext_rescue_protocol_0",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {rom_ext}"
             # First make sure the ROM_EXT is faulting because there is no firmware
             --exec="console --non-interactive --exit-success='BFV:' --exit-failure='PASS|FAIL'"
@@ -388,6 +374,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_bootstrap = "False",
+        testopt_clear_after_test = "True",  # See important note at the top
     ),
 )
 
@@ -401,13 +389,8 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_timeout",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Trigger rescue and do nothing.  We expect the inactivity timer to
             # cause rescue to exit and then boot the firmware.
             --exec="rescue no-op"
@@ -415,6 +398,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -443,7 +428,6 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         # We configure OTP to preserve the reset reason and set the watchdog timeout
         # to one second.
         otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_prod",
@@ -451,10 +435,6 @@ opentitan_test(
         # want to simulate the trigger being jammed.
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Set the trigger with gpio command to simulate the trigger being jammed.
             --exec="gpio set --mode PushPull --value true Ioa2"
             # Check for firmware execution.  We'll enter rescue, timeout,
@@ -462,6 +442,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -482,15 +464,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         exit_failure = "ok: ",
         exit_success = "error: mode not allowed",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_restricted_commands",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Trigger rescue and make sure we can get the device ID.
             --exec="rescue get-device-id --reboot=false"
             # Try the `RESQ` mode and make sure we get an error message.
@@ -499,6 +476,8 @@ opentitan_test(
             --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -520,20 +499,17 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         params = "-p spi-dfu -t gpio -v +Ioa2",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_restricted_commands",
         setup = "--exec=\"gpio set --mode OpenDrain Ioa2\"",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
             {setup}
-            --exec="bootstrap --clear-uart=true {firmware}"
             # Trigger rescue and make sure we can get the device ID.
             --exec="rescue {params} get-device-id --reboot=false"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -552,7 +528,6 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,  # See important note at the top
             exit_success = "BFV:05525304\r\n",
             rom_ext = config.get(
                 "alt_rom_ext",
@@ -561,9 +536,6 @@ opentitan_test(
             setup = config["setup"],
             tags = config["tags"],
             test_cmd = """
-                --exec="transport init"
-                --exec="fpga clear-bitstream"
-                --exec="fpga load-bitstream {bitstream}"
                 {setup}
                 # Load only the ROM_EXT so the boot will fail because of no firmware.
                 --exec="bootstrap --clear-uart=true {rom_ext}"
@@ -571,6 +543,9 @@ opentitan_test(
                 --exec="console --non-interactive --exit-success='{exit_success}' --timeout=10s"
                 no-op
             """,
+            testopt_bootstrap = "False",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for name, config in _CONFIGS.items()
@@ -585,15 +560,15 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             rescue {params} --action=get-boot-log
             """,
             test_harness = "//sw/host/tests/rescue:rescue_test",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -608,17 +583,17 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,  # See important note at the top
             device_id = DEVICE_ID,
             params = config["params"],
             rom_ext = config["rom_ext"],
             test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             --device-id={device_id}
             rescue {params} --action=get-device-id
             """,
             test_harness = "//sw/host/tests/rescue:rescue_test",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -637,14 +612,13 @@ opentitan_test(
                 config["rom_ext"]: "romext",
                 "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
             },
-            changes_otp = True,  # See important note at the top
             params = config["params"],
             test_cmd = """
-            --clear-bitstream
-            --bootstrap={firmware}
             rescue {params} --action=get-owner-page
             """,
             test_harness = "//sw/host/tests/rescue:rescue_test",
+            testopt_clear_after_test = "True",  # See important note at the top
+            testopt_clear_before_test = "True",
         ),
     )
     for protocol, config in _CONFIGS.items()
@@ -662,13 +636,12 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_rescue_disability": "romext",
             "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
         },
-        changes_otp = True,  # See important note at the top
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue --action=disability
         """,
         test_harness = "//sw/host/tests/rescue:rescue_test",
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -684,14 +657,13 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_rescue_disability": "romext",
             "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
         },
-        changes_otp = True,  # See important note at the top
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=disability
         """,
         test_harness = "//sw/host/tests/rescue:rescue_test",
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -705,9 +677,6 @@ opentitan_test(
         assemble = "",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
             --exec="bootstrap --clear-uart=true {rom_ext}"
             # Trigger rescue and make sure we can get the device ID.
             --exec="rescue get-device-id --reboot=false"
@@ -717,6 +686,8 @@ opentitan_test(
             --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
+        testopt_bootstrap = "False",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -733,19 +704,16 @@ opentitan_test(
             ":boot_test_slot_a": "firmware",
         },
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success='warning: rescue' --exit-failure='{exit_failure}'"
             # Trigger rescue and make sure we can get the device ID even if the protocol specified in the rescue
             # config doesn't match the ROM_EXT implementation.
             --exec="rescue get-device-id --reboot=false"
             # Try the `REBO` mode and make sure we reboot without crash.
             --exec="console --non-interactive --send='REBO\r' --exit-success='Finished' --exit-failure='BFV:.*\r\n'"
-            --exec="fpga clear-bitstream"
             no-op
         """,
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -763,11 +731,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=disability
         """,
         test_harness = "//sw/host/tests/rescue:rescue_test",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -784,11 +751,8 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a": "romext",
             ":boot_test_slot_a": "firmware",
         },
-        test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/rescue:xmodem_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -806,11 +770,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=spi-dfu-state-transitions
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -828,11 +791,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=invalid-spi-dfu-requests
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -850,11 +812,10 @@ opentitan_test(
         },
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=invalid-spi-flash-transaction
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -872,11 +833,10 @@ opentitan_test(
         },
         params = "-p usb-dfu -t strap -v 3",
         test_cmd = """
-        --clear-bitstream
-        --bootstrap={firmware}
         rescue {params} --action=usb-dfu-out-chunk-too-big
         """,
         test_harness = "//sw/host/tests/rescue:dfu_rescue_error_handling",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -892,17 +852,10 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         exit_failure = "(FAIL|BFV:|mode: RESQ).*",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
-        test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
-            --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
-            no-op
-        """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",
@@ -925,19 +878,16 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,  # See important note at the top
         exit_success = "mode: RESQ",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_enter_on_watchdog",
         test_cmd = """
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
-            --exec="bootstrap --clear-uart=true {firmware}"
             --exec="console --non-interactive --exit-success='{exit_success}' --exit-failure='{exit_failure}'"
             # Try the `REBO` mode and make sure we reboot without crash.
             --exec="console --non-interactive --send='REBO\r' --exit-success='ROM:' --exit-failure='BFV:.*\r\n'"
             no-op
         """,
+        testopt_clear_after_test = "True",  # See important note at the top
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//sw/device/lib/base:status",

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/BUILD
@@ -98,6 +98,11 @@ _CONFIGS = {
     for name, position in _POSITIONS.items()
 ]
 
+# Important note: many of the tests in this file modify the owner
+# configuration and/or expect an empty owner configuration when
+# starting the test. Currently, the only way to clear this configuration
+# is to clear the bitstream.
+
 [
     opentitan_test(
         name = "rescue_firmware_{}_{}".format(name, protocol),
@@ -110,7 +115,7 @@ _CONFIGS = {
             binaries = {
                 ":boot_test_{}".format(name): "payload",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
@@ -171,7 +176,7 @@ genrule(
                 ":boot_test_{}".format(name): "payload",
                 ":bad_rom_ext": "bad_rom_ext",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             exit_failure = _RESCUE_ROMEXT_RESULTS[name == rxslot]["failure"],
             exit_success = _RESCUE_ROMEXT_RESULTS[name == rxslot]["success"].format(slot = name),
             image_name = "rescue_rom_ext_{}.img".format(name),
@@ -211,7 +216,7 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
@@ -251,7 +256,7 @@ genrule(
                 ":boot_test_slot_a": "slot_a",
                 ":boot_test_slot_b": "slot_b",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             setup = config["setup"],
@@ -293,7 +298,7 @@ genrule(
             binaries = {
                 ":boot_test_slot_a": "payload",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             rate = rate,
             test_cmd = """
                 --exec="transport init"
@@ -328,7 +333,7 @@ genrule(
             binaries = {
                 ":boot_test_slot_a": "payload",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             rate = rate,
             test_cmd = """
                 --exec="transport init"
@@ -369,7 +374,7 @@ opentitan_test(
         binaries = {
             ":boot_test_slot_a": "payload",
         },
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         rom_ext = "//sw/device/silicon_creator/rom_ext/e2e/rescue/testdata:rom_ext_rescue_protocol_0",
         test_cmd = """
             --exec="transport init"
@@ -396,7 +401,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_timeout",
         test_cmd = """
             --exec="transport init"
@@ -438,7 +443,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         # We configure OTP to preserve the reset reason and set the watchdog timeout
         # to one second.
         otp = "//sw/device/silicon_creator/rom_ext/e2e:otp_img_secret2_locked_preserve_reset_prod",
@@ -477,7 +482,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         exit_failure = "ok: ",
         exit_success = "error: mode not allowed",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_restricted_commands",
@@ -515,7 +520,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         params = "-p spi-dfu -t gpio -v +Ioa2",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_restricted_commands",
         setup = "--exec=\"gpio set --mode OpenDrain Ioa2\"",
@@ -547,7 +552,7 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             exit_success = "BFV:05525304\r\n",
             rom_ext = config.get(
                 "alt_rom_ext",
@@ -580,7 +585,7 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             params = config["params"],
             rom_ext = config["rom_ext"],
             test_cmd = """
@@ -603,7 +608,7 @@ opentitan_test(
         },
         fpga = fpga_params(
             assemble = "",
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             device_id = DEVICE_ID,
             params = config["params"],
             rom_ext = config["rom_ext"],
@@ -632,7 +637,7 @@ opentitan_test(
                 config["rom_ext"]: "romext",
                 "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
             },
-            changes_otp = True,
+            changes_otp = True,  # See important note at the top
             params = config["params"],
             test_cmd = """
             --clear-bitstream
@@ -657,7 +662,7 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_rescue_disability": "romext",
             "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
         },
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         test_cmd = """
         --clear-bitstream
         --bootstrap={firmware}
@@ -679,7 +684,7 @@ opentitan_test(
             "//sw/device/silicon_creator/rom_ext:rom_ext_spidfu_rescue_disability": "romext",
             "//sw/device/silicon_creator/rom_ext/e2e/attestation:print_certs": "firmware",
         },
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         params = "-p spi-dfu -t gpio -v +Ioa2",
         test_cmd = """
         --clear-bitstream
@@ -887,7 +892,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         exit_failure = "(FAIL|BFV:|mode: RESQ).*",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_dice_x509_slot_a",
         test_cmd = """
@@ -920,7 +925,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw340_rom_ext": None,
     },
     fpga = fpga_params(
-        changes_otp = True,
+        changes_otp = True,  # See important note at the top
         exit_success = "mode: RESQ",
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_xmodem_enter_on_watchdog",
         test_cmd = """

--- a/sw/device/silicon_creator/rom_ext/e2e/rescue/std_utils/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/rescue/std_utils/BUILD
@@ -21,13 +21,14 @@ opentitan_test(
         binaries = {
             "//sw/device/silicon_creator/rom_ext/e2e/rescue:boot_test_slot_a": "boot_test",
         },
-        changes_otp = True,
         test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             --firmware={boot_test}
         """,
         test_harness = "//sw/host/tests/rescue:xmodem_protocol",
+        testopt_bootstrap = "False",
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )
 
@@ -42,15 +43,16 @@ opentitan_test(
         binaries = {
             "//sw/device/silicon_creator/rom_ext/e2e/rescue:boot_test_slot_a": "boot_test",
         },
-        changes_otp = True,
         rom_ext = "//sw/device/silicon_creator/rom_ext:rom_ext_usbdfu",
         test_cmd = """
-            --clear-bitstream
             --bootstrap={rom_ext}
             --firmware={boot_test}
             --trigger=strap
             --value=3
         """,
         test_harness = "//sw/host/tests/rescue:usbdfu_protocol",
+        testopt_bootstrap = "False",
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )

--- a/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
+++ b/sw/device/silicon_creator/rom_ext/e2e/secver/BUILD
@@ -116,7 +116,6 @@ opentitan_test(
             ":rom_ext_2": "rom_ext2",
             ":rom_ext_3": "rom_ext3",
         },
-        changes_otp = True,
         exit_success = "BFV:{}".format(hex_digits(CONST.BFV.BOOT_POLICY.ROLLBACK)),
         rom_ext = ":rom_ext_0",
         test_cmd = """
@@ -124,12 +123,8 @@ opentitan_test(
             --exec="image assemble -s 524288 --mirror=false -o fw1.bin {rom_ext1}@{rom_ext_slot_a} {boot_test}@{owner_slot_a}"
             --exec="image assemble -s 524288 --mirror=false -o fw2.bin {rom_ext2}@{rom_ext_slot_a} {boot_test}@{owner_slot_a}"
             --exec="image assemble -s 524288 --mirror=false -o fw3.bin {rom_ext3}@{rom_ext_slot_a} {boot_test}@{owner_slot_a}"
-            --exec="transport init"
-            --exec="fpga clear-bitstream"
-            --exec="fpga load-bitstream {bitstream}"
 
-            # Bootstrap the initial version 0 into SlotA
-            --exec="bootstrap --clear-uart=true {firmware}"
+            # Check the initial version 0 has been bootstrapped into SlotA
             --exec="console --non-interactive --exit-success='rom_ext_min_sec_ver = 0'"
 
             # Rescue and update to SlotB.  We expect to update the secver.
@@ -149,6 +144,8 @@ opentitan_test(
             --exec="console --non-interactive --exit-success='{exit_success}' --timeout=10s"
             no-op
         """,
+        testopt_clear_after_test = "True",
+        testopt_clear_before_test = "True",
     ),
 )
 

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -1665,10 +1665,7 @@ opentitan_test(
         EARLGREY_CW340_TEST_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "\"{firmware:elf}\"",
-        ]),
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/mem",
     ),
     verilator = verilator_params(
@@ -2029,6 +2026,7 @@ opentitan_test(
             " \"{firmware}\"",
         ]),
         test_harness = "//sw/host/tests/chip/flash_ctrl:host_rma_test",
+        testopt_bootstrap = "False",
     ),
     kind = "ram",
     linker_script = "//sw/device/silicon_creator/manuf/lib:sram_program_linker_script",
@@ -2086,9 +2084,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/gpio:gpio_pinmux",
     ),
     silicon = silicon_params(
@@ -2119,9 +2114,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         timeout = "moderate",
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/gpio:gpio_intr",
     ),
     silicon = silicon_params(
@@ -3122,10 +3114,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/pwm_smoketest",
     ),
     silicon = silicon_params(
@@ -3192,9 +3181,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
     silicon = silicon_params(
@@ -3231,9 +3217,6 @@ opentitan_test(
         EARLGREY_TEST_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
     silicon = silicon_params(
@@ -3274,7 +3257,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = "--bootstrap={firmware}",
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
     silicon = silicon_params(
@@ -3309,7 +3291,6 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = "--bootstrap={firmware}",
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_resets",
     ),
     silicon = silicon_params(
@@ -3347,9 +3328,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
     ),
     silicon = silicon_params(
@@ -3388,9 +3366,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_por",
     ),
     silicon = silicon_params(
@@ -3430,9 +3405,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
     silicon = silicon_params(
@@ -3471,9 +3443,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
     silicon = silicon_params(
@@ -3514,9 +3483,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
     silicon = silicon_params(
@@ -3562,9 +3528,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-        """,
         test_harness = "//sw/host/tests/chip/pwrmgr:sleep_all_wakeups",
     ),
     silicon = silicon_params(
@@ -3603,10 +3566,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/gpio:sleep_pin_wake",
     ),
     silicon = silicon_params(
@@ -3913,10 +3873,7 @@ opentitan_test(
     fpga = fpga_params(
         # This test requires the spi full duplex on the hyperdebug board.
         tags = ["manual"],
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_tpm_test",
     ),
     silicon = silicon_params(
@@ -3954,10 +3911,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_flash_smoketest",
     ),
     qemu = qemu_params(
@@ -4004,10 +3958,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device_ujson_console_test",
     ),
     deps = [
@@ -4035,9 +3986,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/spi_device:spi_device_sleep_test",
     ),
     silicon = silicon_params(
@@ -4161,10 +4109,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device:spi_host_config_test",
     ),
     silicon = silicon_params(
@@ -4378,12 +4323,9 @@ opentitan_test(
         # is not run in CI which causes a CI error ("Verify FPGA Jobs" check
         # will fail).
         tags = ["manuf"],
-        test_cmd = """
-            --clear-bitstream
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/ottf_console_with_gpio_tx_indicator",
+        testopt_clear_before_test = "True",
     ),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -4406,10 +4348,7 @@ opentitan_test(
         EARLGREY_CW340_TEST_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device_ottf_console",
     ),
     deps = [
@@ -4432,9 +4371,6 @@ opentitan_test(
         EARLGREY_CW340_TEST_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/ottf_dual_console",
     ),
     deps = [
@@ -4603,7 +4539,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4638,7 +4573,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4702,7 +4636,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4747,7 +4680,6 @@ opentitan_test(
     fpga = fpga_params(
         tags = ["manual"],
         test_cmd = """
-            --bootstrap="{firmware}"
             --wake=reset
         """,
         test_harness = "//sw/host/tests/chip/usb:usbdev_aon_wake",
@@ -4782,7 +4714,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4818,7 +4749,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4858,9 +4788,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         tags = ["manual"],
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/usb:usbdev_smoketest",
     ),
     silicon = silicon_params(
@@ -4916,7 +4843,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --exec=$(rootpath :usbdev_stream_host_harness)
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4955,7 +4881,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --exec=$(rootpath :usbdev_stream_host_harness)
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -4994,7 +4919,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --exec=$(rootpath :usbdev_stream_host_harness)
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -5030,7 +4954,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --no-wait-for-usb-device
         """,
         test_harness = "//sw/host/tests/chip/usb:usb_harness",
@@ -5118,7 +5041,6 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=suspend
             --init-phase=suspend
         """,
@@ -5156,7 +5078,6 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=sleep-resume
             --init-phase=sleep-resume
         """,
@@ -5195,7 +5116,6 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=sleep-reset
             --init-phase=sleep-resume
         """,
@@ -5236,7 +5156,6 @@ opentitan_test(
         timeout = "eternal",
         tags = ["manual"],
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=deep-resume
             --init-phase=sleep-disconnect
         """,
@@ -5275,7 +5194,6 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=deep-resume
             --init-phase=deep-resume
         """,
@@ -5314,7 +5232,6 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=deep-reset
             --init-phase=deep-resume
         """,
@@ -5353,7 +5270,6 @@ opentitan_test(
     ],
     cw310 = fpga_params(
         test_cmd = """
-            --bootstrap="{firmware}"
             --fin-phase=shutdown
             --init-phase=deep-disconnect
         """,
@@ -5641,9 +5557,6 @@ opentitan_test(
     ),
     fpga = fpga_params(
         otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_prod_manuf_personalized",
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/power_virus",
     ),
     silicon = silicon_params(
@@ -5712,18 +5625,12 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device:spi_passthru",
     ),
     hyper310 = fpga_params(
         tags = ["manual"],  # TODO: QE bit handling
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/spi_device:spi_passthru",
     ),
     silicon = silicon_params(
@@ -5843,7 +5750,6 @@ _RV_DM_TEST_CONFIGURATIONS = [
                 "lc_{}".format(test_cfg["lc_state"]),
             ],
             test_cmd = """
-                --bootstrap="{firmware}"
                 {rv_dm_delayed_en}
             """,
             test_harness = "//sw/host/tests/chip/rv_dm:csr_rw",
@@ -5888,7 +5794,6 @@ test_suite(
             ],
             test_cmd = """
                 --rom={rom:binary}
-                --bootstrap="{firmware}"
                 {rv_dm_delayed_en}
             """,
             test_harness = "//sw/host/tests/chip/rv_dm:mem_access",
@@ -6078,6 +5983,7 @@ test_suite(
             ],
             test_cmd = " --expect-fail" if lc_state_val in _LC_STATES_DEBUG_DISALLOWED else "",
             test_harness = "//sw/host/tests/chip/rv_dm:lc_disabled",
+            testopt_bootstrap = "False",
         ),
         silicon = silicon_params(
             needs_jtag = True,
@@ -6115,9 +6021,6 @@ test_suite(
             tags = [
                 "lc_{}".format(lc_state),
             ],
-            test_cmd = """
-                --bootstrap="{firmware}"
-            """,
             test_harness = "//sw/host/tests/chip/rv_dm:ndm_reset_req",
         ),
         deps = [
@@ -6169,9 +6072,6 @@ test_suite(
             tags = [
                 "lc_{}".format(lc_state),
             ],
-            test_cmd = """
-                --bootstrap="{firmware}"
-            """,
             test_harness = "//sw/host/tests/chip/rv_dm:ndm_reset_req_when_cpu_halted",
         ),
         deps = [
@@ -6210,9 +6110,6 @@ test_suite(
             tags = [
                 "lc_{}".format(lc_state),
             ],
-            test_cmd = """
-                --bootstrap="{firmware}"
-            """,
             test_harness = "//sw/host/tests/chip/rv_dm:dtm",
         ),
         deps = [
@@ -6251,9 +6148,6 @@ test_suite(
             tags = [
                 "lc_{}".format(lc_state),
             ],
-            test_cmd = """
-                --bootstrap="{firmware}"
-            """,
             test_harness = "//sw/host/tests/chip/rv_dm:control_status",
         ),
         deps = [
@@ -6293,7 +6187,6 @@ test_suite(
                 "lc_{}".format(lc_state),
             ],
             test_cmd = """
-                --bootstrap="{firmware}"
                 --firmware-elf=\"{firmware:elf}\"
             """,
             test_harness = "//sw/host/tests/chip/rv_dm:access_after_wakeup",
@@ -6351,7 +6244,6 @@ test_suite(
                 "lc_{}".format(lc_state),
             ],
             test_cmd = """
-                --bootstrap="{firmware}"
                 --firmware-elf=\"{firmware:elf}\"
             """,
             test_harness = "//sw/host/tests/chip/rv_dm:access_after_hw_reset",
@@ -6391,9 +6283,6 @@ opentitan_test(
         otp = "//hw/ip/otp_ctrl/data:img_test_unlocked0",
         # TODO(#22823): Remove "broken" tag once the test is fixed.
         tags = ["broken"],
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/jtag:openocd_test",
     ),
     deps = [
@@ -6411,10 +6300,7 @@ opentitan_test(
         "//hw/top_earlgrey:fpga_cw310_sival": None,
     },
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/i2c_target:i2c_target_smbus_arp",
     ),
     deps = [
@@ -6443,10 +6329,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/i2c_host_override",
     ),
     silicon = silicon_params(
@@ -6486,9 +6369,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/i2c_target",
     ),
     silicon = silicon_params(
@@ -6577,10 +6457,7 @@ opentitan_test(
         "//hw/top_earlgrey:sim_verilator": None,
     },
     fpga = fpga_params(
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "\"{firmware:elf}\"",
-        ]),
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/example_sival",
     ),
     # This test can take > 40 minutes, so mark it manual as it shouldn't run
@@ -6603,10 +6480,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_inputs",
     ),
     silicon = silicon_params(
@@ -6640,10 +6514,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_outputs",
     ),
     silicon = silicon_params(
@@ -6678,10 +6549,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_in_irq",
     ),
     silicon = silicon_params(
@@ -6717,9 +6585,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_ec_rst_l",
     ),
     silicon = silicon_params(
@@ -6755,9 +6620,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_ulp_z3_wakeup",
     ),
     silicon = silicon_params(
@@ -6797,10 +6659,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-            "{firmware:elf}"
-        """,
+        test_cmd = "{firmware:elf}",
         test_harness = "//sw/host/tests/chip/sysrst_ctrl:sysrst_ctrl_reset",
     ),
     silicon = silicon_params(
@@ -6887,6 +6746,7 @@ opentitan_test(
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_isa",
+        testopt_bootstrap = "False",
     ),
     silicon = silicon_params(
         needs_jtag = True,
@@ -6976,6 +6836,7 @@ opentitan_test(
         tags = ["manual"],
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
+        testopt_bootstrap = "False",
     ),
     silicon = silicon_params(
         needs_jtag = True,
@@ -7037,10 +6898,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "--firmware-elf=\"{firmware:elf}\"",
-        ]),
+        test_cmd = "--firmware-elf={firmware:elf}",
         test_harness = "//sw/host/tests/chip/uart:uart_tx_rx",
     ),
     silicon = silicon_params(
@@ -7097,6 +6955,7 @@ opentitan_test(
         otp = "//sw/device/silicon_creator/manuf/tests:otp_img_rom_exec_disabled_test_unlocked0",
         test_cmd = "--elf={sram_program}",
         test_harness = "//sw/host/tests/chip/rv_core_ibex_epmp",
+        testopt_bootstrap = "False",
     ),
     silicon = silicon_params(
         binaries = {
@@ -7191,10 +7050,7 @@ opentitan_test(
         EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
     ),
     fpga = fpga_params(
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "--firmware-elf=\"{firmware:elf}\"",
-        ]),
+        test_cmd = "--firmware-elf={firmware:elf}",
         test_harness = "//sw/host/tests/chip/uart:uart_baud_rate",
     ),
     silicon = silicon_params(
@@ -7235,10 +7091,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "--firmware-elf=\"{firmware:elf}\"",
-        ]),
+        test_cmd = "--firmware-elf={firmware:elf}",
         test_harness = "//sw/host/tests/chip/uart:uart_loopback",
     ),
     silicon = silicon_params(
@@ -7317,10 +7170,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "--firmware-elf=\"{firmware:elf}\"",
-        ]),
+        test_cmd = "--firmware-elf={firmware:elf}",
         test_harness = "//sw/host/tests/chip/uart:uart_parity_break",
     ),
     silicon = silicon_params(
@@ -7426,10 +7276,7 @@ opentitan_test(
         timeout = "moderate",
         needs_jtag = True,
         otp = "//hw/ip/otp_ctrl/data/earlgrey_skus/emulation:otp_img_rma_manuf_personalized",
-        test_cmd = " ".join([
-            "--bootstrap=\"{firmware}\"",
-            "--firmware-elf=\"{firmware:elf}\"",
-        ]),
+        test_cmd = "--firmware-elf={firmware:elf}",
         test_harness = "//sw/host/tests/chip/sram_ctrl:sram_ctrl_lc_escalation",
     ),
     deps = [
@@ -7459,9 +7306,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/gpio:sleep_pin_mio_dio_val",
     ),
     silicon = silicon_params(
@@ -7503,9 +7347,6 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap="{firmware}"
-        """,
         test_harness = "//sw/host/tests/chip/gpio:sleep_pin_retention",
     ),
     silicon = silicon_params(
@@ -7546,10 +7387,7 @@ opentitan_test(
         },
     ),
     fpga = fpga_params(
-        test_cmd = """
-            --bootstrap={firmware}
-            --firmware-elf=\"{firmware:elf}\"
-        """,
+        test_cmd = "--firmware-elf={firmware:elf}",
         test_harness = "//sw/host/tests/chip/pattgen:pattgen_ios",
     ),
     silicon = silicon_params(

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -64,18 +64,14 @@ def cryptotest(name, test_vectors, test_args, test_harness, slow_test = False):
             timeout = "long",
             data = test_vectors,
             tags = tags,
-            test_cmd = """
-                --bootstrap={firmware}
-            """ + test_args,
+            test_cmd = test_args,
             test_harness = test_harness,
         ),
         fpga_cw340 = fpga_params(
             timeout = "long",
             tags = tags,
             data = test_vectors,
-            test_cmd = """
-                --bootstrap={firmware}
-            """ + test_args,
+            test_cmd = test_args,
             test_harness = test_harness,
         ),
         exec_env = CRYPTOTEST_EXEC_ENVS,

--- a/sw/host/opentitanlib/src/rescue/dfu.rs
+++ b/sw/host/opentitanlib/src/rescue/dfu.rs
@@ -61,9 +61,9 @@ with_unknown! {
 #[derive(Clone, Copy)]
 #[repr(u8)]
 pub enum DfuRequestType {
-    Out = 0x21,       // direction=out, type=class, recipient=interface.
-    In = 0xA1,        // direction=in, type=class, recipient=interface.
-    Vendor = 0x40,    // direction=out, type=vendor, recipient=device.
+    Out = 0x21,    // direction=out, type=class, recipient=interface.
+    In = 0xA1,     // direction=in, type=class, recipient=interface.
+    Vendor = 0x40, // direction=out, type=vendor, recipient=device.
 }
 
 impl From<DfuRequestType> for u8 {

--- a/sw/host/opentitanlib/src/rescue/spidfu.rs
+++ b/sw/host/opentitanlib/src/rescue/spidfu.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::{Duration, Instant};

--- a/sw/host/opentitanlib/src/test_utils/init.rs
+++ b/sw/host/opentitanlib/src/test_utils/init.rs
@@ -29,6 +29,10 @@ pub struct InitializeTest {
     #[arg(long, default_value = "off")]
     pub logging: LevelFilter,
 
+    /// De-assert reset signal before executing commands.
+    #[arg(short, long)]
+    drop_reset: bool,
+
     #[command(flatten)]
     pub backend_opts: backend::BackendOpts,
 
@@ -139,6 +143,10 @@ impl InitializeTest {
 
         // Set up the default pin configurations as specified in the transport's config file.
         transport.apply_default_configuration(None)?;
+
+        if self.drop_reset {
+            transport.pin_strapping("RESET")?.remove()?;
+        }
 
         // Create the UART first to initialize the desired parameters.
         let _uart = self.bootstrap.options.uart_params.create(&transport)?;

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -14,6 +14,7 @@ rust_binary(
         "src/command/bootstrap.rs",
         "src/command/certificate.rs",
         "src/command/clear_bitstream.rs",
+        "src/command/clear_instrumented_rom.rs",
         "src/command/console.rs",
         "src/command/ecdsa.rs",
         "src/command/emulator.rs",

--- a/sw/host/opentitantool/src/command/clear_instrumented_rom.rs
+++ b/sw/host/opentitantool/src/command/clear_instrumented_rom.rs
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors (OpenTitan project).
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use clap::Args;
+use std::any::Any;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::{StagedProgressBar, TransportWrapper};
+use opentitanlib::bootstrap::{Bootstrap, BootstrapOptions};
+use opentitanlib::transport::common::fpga;
+use opentitanlib::util::parse_int::ParseInt;
+
+/// Clear the instrumented ROM.
+#[derive(Debug, Args)]
+pub struct ClearInstrumentedRomCommand {
+    #[command(flatten)]
+    bootstrap_options: BootstrapOptions,
+    /// The byte offset to the instrumented rom slot.
+    #[arg(long, value_parser = usize::from_str)]
+    slot: usize,
+    /// The byte offset to the magic bytes in the instrumented rom.
+    #[arg(long, value_parser = usize::from_str, default_value = "0x180")]
+    magic_bytes_offset: usize,
+}
+
+impl ClearInstrumentedRomCommand {
+    fn clear_by_bootstrap(&self, transport: &TransportWrapper) -> Result<()> {
+        // Pad to magic bytes
+        let mut payload = vec![0xff; self.slot + self.magic_bytes_offset];
+        // Clear magic bytes with zeros
+        payload.extend_from_slice(&[0x00; 4]);
+
+        let progress = StagedProgressBar::new();
+        Bootstrap::update_with_progress(transport, &self.bootstrap_options, &payload, &progress)
+    }
+}
+
+impl CommandDispatch for ClearInstrumentedRomCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
+        if let Err(e) = self.clear_by_bootstrap(transport) {
+            log::warn!(
+                "Could not clear instrumented ROM via bootstrap, falling back to clear bitstream: {e}"
+            );
+            transport.dispatch(&fpga::ClearBitstream)?;
+        }
+        Ok(None)
+    }
+}

--- a/sw/host/opentitantool/src/command/fpga.rs
+++ b/sw/host/opentitantool/src/command/fpga.rs
@@ -15,4 +15,5 @@ pub enum FpgaCommand {
     ResetSam3x(crate::command::sam3x::Reset),
     SetPll(crate::command::set_pll::SetPll),
     UpdateUsrAccess(crate::command::update_usr_access::UpdateUsrAccess),
+    ClearInstrumentedRom(crate::command::clear_instrumented_rom::ClearInstrumentedRomCommand),
 }

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -6,6 +6,7 @@ pub mod bfv;
 pub mod bootstrap;
 pub mod certificate;
 pub mod clear_bitstream;
+pub mod clear_instrumented_rom;
 pub mod console;
 pub mod ecdsa;
 pub mod emulator;

--- a/sw/host/opentitantool/src/command/rescue.rs
+++ b/sw/host/opentitantool/src/command/rescue.rs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Result, anyhow};
 use clap::{Args, Subcommand};
 use serde_annotate::Annotate;
 use std::any::Any;
@@ -16,7 +16,6 @@ use opentitanlib::chip::helper::{OwnershipActivateParams, OwnershipUnlockParams}
 use opentitanlib::image::image::Image;
 use opentitanlib::image::manifest::ManifestKind;
 use opentitanlib::ownership::{OwnerBlock, TlvHeader};
-use opentitanlib::rescue::xmodem::XmodemError;
 use opentitanlib::rescue::{EntryMode, RescueMode, RescueParams};
 use opentitanlib::util::file::FromReader;
 use opentitanlib::util::parse_int::ParseInt;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -110,6 +110,10 @@ struct Opts {
     #[arg(long, num_args = 1)]
     exec: Vec<String>,
 
+    /// De-assert reset signal before executing commands.
+    #[arg(short, long)]
+    drop_reset: bool,
+
     #[command(flatten)]
     backend_opts: backend::BackendOpts,
 
@@ -231,6 +235,10 @@ fn main() -> Result<()> {
     let opts = parse_command_line(Opts::parse(), args_os())?;
 
     let transport = backend::create(&opts.backend_opts)?;
+
+    if opts.drop_reset {
+        transport.pin_strapping("RESET")?.remove()?;
+    }
 
     for command in &opts.exec {
         execute(

--- a/sw/host/tests/rescue/rescue_test.rs
+++ b/sw/host/tests/rescue/rescue_test.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::bool_assert_comparison)]
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use base64ct::{Base64, Decoder};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};

--- a/sw/host/tests/rescue/xmodem_rescue_error_handling.rs
+++ b/sw/host/tests/rescue/xmodem_rescue_error_handling.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![allow(clippy::bool_assert_comparison)]
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::Parser;
 
 use std::rc::Rc;
@@ -131,7 +131,6 @@ fn send_data_crc_error_cancel(
     uart.write(&buf)?;
     uart.read(std::slice::from_mut(&mut ch))?;
     assert_eq!(ch, CAN);
-
 
     // Ensure we can still boot into Owner SW.
     UartConsole::wait_for(uart, r"Finished", Duration::from_secs(5))?;
@@ -398,10 +397,12 @@ fn rescue_image_too_big(
     rescue: &RescueSerial,
 ) -> Result<()> {
     rescue.enter(transport, EntryMode::Reset)?;
-    let image_too_big = [0u8; 1026*1024];
+    let image_too_big = [0u8; 1026 * 1024];
     match rescue.update_firmware(BootSlot::SlotB, &image_too_big) {
         Ok(_) => {
-            return Err(anyhow!("Expects cancel during firmware rescue, but got OK."));
+            return Err(anyhow!(
+                "Expects cancel during firmware rescue, but got OK."
+            ));
         }
         Err(e) => {
             if e.to_string().contains("Cancelled") {


### PR DESCRIPTION
Refactor the instrumented ROM loader and bootstrapping logic to support coverage collection. This includes adding the `clear-instrumented-rom` command to opentitantool and cleaning up the instrumented ROM after tests.

Backport the `testopt` infrastructure to simplify Bazel test command definitions and apply it to various FPGA test targets.